### PR TITLE
Add maintenance module, auto-login, and custom role rights

### DIFF
--- a/admin_problem.php
+++ b/admin_problem.php
@@ -17,13 +17,14 @@ try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
     exit;
 }
 
-if ($role_id != 1) {
-    echo "Access denied. Admins only.";
+if (!in_array('admin_problem', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/analytics.php
+++ b/analytics.php
@@ -24,13 +24,14 @@ try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
     exit;
 }
 
-if ($role_id != 1) {
-    echo "Access denied. Admins only.";
+if (!in_array('analytics', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/dashboard.php
+++ b/dashboard.php
@@ -16,6 +16,7 @@ try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $username = $decoded->username;
     $role_id = $decoded->role_id;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     session_destroy();
     header('Location: login.php');

--- a/init.sql
+++ b/init.sql
@@ -121,6 +121,45 @@ INSERT INTO `roles` (`id`, `name`) VALUES
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `role_rights`
+--
+
+CREATE TABLE `role_rights` (
+  `role_id` int(11) NOT NULL,
+  `right_name` varchar(50) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `role_rights`
+--
+
+INSERT INTO `role_rights` (`role_id`, `right_name`) VALUES
+(1, 'settings'),
+(1, 'rosters'),
+(1, 'tickets'),
+(1, 'my_roster'),
+(1, 'analytics'),
+(1, 'maintenance'),
+(1, 'report_problem'),
+(1, 'admin_problem'),
+(1, 'user_management'),
+(1, 'roles_management'),
+(1, 'logout'),
+(2, 'rosters'),
+(2, 'tickets'),
+(2, 'my_roster'),
+(2, 'maintenance'),
+(2, 'report_problem'),
+(2, 'logout'),
+(3, 'tickets'),
+(3, 'logout'),
+(4, 'my_roster'),
+(4, 'report_problem'),
+(4, 'logout');
+
+-- --------------------------------------------------------
+
+--
 -- Tabelstructuur voor tabel `sales`
 --
 
@@ -254,6 +293,12 @@ ALTER TABLE `roles`
   ADD UNIQUE KEY `name` (`name`);
 
 --
+-- Indexen voor tabel `role_rights`
+--
+ALTER TABLE `role_rights`
+  ADD KEY `role_id` (`role_id`);
+
+--
 -- Indexen voor tabel `sales`
 --
 ALTER TABLE `sales`
@@ -379,6 +424,12 @@ ALTER TABLE `tickets`
 ALTER TABLE `users`
   ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`);
+
+--
+-- Beperkingen voor tabel `role_rights`
+--
+ALTER TABLE `role_rights`
+  ADD CONSTRAINT `role_rights_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`) ON DELETE CASCADE;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/login.php
+++ b/login.php
@@ -19,11 +19,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         if ($user && password_verify($password, $user['password_hash'])) {
             // Create JWT payload
+            $stmt = $pdo->prepare("SELECT right_name FROM role_rights WHERE role_id = ?");
+            $stmt->execute([$user['role_id']]);
+            $rights = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
             $payload = [
                 'sub' => $user['id'],
                 'username' => $user['username'],
                 'role_id' => $user['role_id'],
                 'account_id' => $user['account_id'],
+                'rights' => $rights,
                 'iat' => time(),
                 'exp' => time() + (60 * 60) // 1 hour
             ];

--- a/maintenance.php
+++ b/maintenance.php
@@ -1,0 +1,50 @@
+<?php
+require 'vendor/autoload.php';
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+session_start();
+$jwt_secret = 'your-secret-key';
+
+if (!isset($_SESSION['jwt'])) {
+    http_response_code(401);
+    echo "Not authenticated";
+    exit;
+}
+
+try {
+    $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
+    $role_id = $decoded->role_id;
+    $rights = $decoded->rights ?? [];
+} catch (Exception $e) {
+    echo "Invalid session.";
+    exit;
+}
+
+if (!in_array('maintenance', $rights)) {
+    echo "Access denied.";
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Maintenance | RatPack Park</title>
+    <style>
+        body { font-family: Arial; background: #f5f5fc; padding: 20px; }
+        h2 { color: #6a1b9a; }
+        ul { background: white; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
+        li { margin: 8px 0; }
+    </style>
+    </head>
+<body>
+    <h2>🛠️ Maintenance Tasks</h2>
+    <ul>
+        <li>Check roller coaster brakes</li>
+        <li>Inspect water slides</li>
+        <li>Test safety harnesses</li>
+    </ul>
+</body>
+</html>
+

--- a/menu.php
+++ b/menu.php
@@ -1,19 +1,20 @@
 <?php
-// Menu logic based on $role_id from dashboard.php
+// Menu logic based on rights from dashboard.php
 $menu_items = [
-    ['label' => 'Settings', 'url' => 'settings.php', 'roles' => [1]],
-    ['label' => 'Rosters', 'url' => 'rosters.php', 'roles' => [1, 2]],
-    ['label' => 'Tickets', 'url' => 'tickets.php', 'roles' => [1, 2, 3]],
-    ['label' => 'My Roster', 'url' => 'my_roster.php', 'roles' => [1, 2, 4]],
-    ['label' => 'Analytics', 'url' => 'analytics.php', 'roles' => [1]],
-    ['label' => 'Report a problem', 'url' => 'problem.php', 'roles' => [1,2,4]],
-    ['label' => 'Admin problem overview', 'url' => 'admin_problem.php', 'roles' => [1]],
-    ['label' => 'Logout', 'url' => 'logout.php', 'roles' => [1,2,3,4]],
-
+    ['label' => 'Settings', 'url' => 'settings.php', 'rights' => ['settings']],
+    ['label' => 'Rosters', 'url' => 'rosters.php', 'rights' => ['rosters']],
+    ['label' => 'Tickets', 'url' => 'tickets.php', 'rights' => ['tickets']],
+    ['label' => 'My Roster', 'url' => 'my_roster.php', 'rights' => ['my_roster']],
+    ['label' => 'Analytics', 'url' => 'analytics.php', 'rights' => ['analytics']],
+    ['label' => 'Maintenance', 'url' => 'maintenance.php', 'rights' => ['maintenance']],
+    ['label' => 'Report a problem', 'url' => 'problem.php', 'rights' => ['report_problem']],
+    ['label' => 'Admin problem overview', 'url' => 'admin_problem.php', 'rights' => ['admin_problem']],
+    ['label' => 'Role Management', 'url' => 'role_management.php', 'rights' => ['roles_management']],
+    ['label' => 'Logout', 'url' => 'logout.php', 'rights' => ['logout']],
 ];
 
 foreach ($menu_items as $item) {
-    if (in_array($role_id, $item['roles'])) {
+    if (!empty(array_intersect($rights, $item['rights']))) {
         echo "<a href=\"{$item['url']}\" target=\"mainframe\">{$item['label']}</a>";
     }
 }

--- a/my_roster.php
+++ b/my_roster.php
@@ -18,13 +18,14 @@ try {
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id;
     $user_id = $decoded->sub;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
     exit;
 }
 
-if (!in_array($role_id, [1, 2, 4])) {
-    echo "Access denied. This page is for admins, managers, and operators only.";
+if (!in_array('my_roster', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/problem.php
+++ b/problem.php
@@ -16,6 +16,7 @@ if (!isset($_SESSION['jwt'])) {
 try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $role_id = $decoded->role_id;
+    $rights = $decoded->rights ?? [];
     $account_id = $decoded->account_id;
     $submitted_by = $decoded->sub;
 } catch (Exception $e) {
@@ -23,8 +24,8 @@ try {
     exit;
 }
 
-if (!in_array($role_id, [1, 2, 4])) {
-    echo "Access denied. Only Admins and Managers can report problems.";
+if (!in_array('report_problem', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/register.php
+++ b/register.php
@@ -2,14 +2,12 @@
 // register.php (admin-only registration + intro explanation)
 require 'vendor/autoload.php';
 require 'db.php';
+use Firebase\JWT\JWT;
+
+session_start();
 
 // Force all registrations to be admin-level (role_id = 1)
 $role_id = 1;
-// Create a new account for this admin
-$stmt = $pdo->prepare("INSERT INTO accounts (name, contact_email) VALUES (?, ?)");
-$accountName = $username . "'s Theme Park";
-$stmt->execute([$accountName, $email]);
-$account_id = $pdo->lastInsertId();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = $_POST['username'] ?? '';
@@ -19,12 +17,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$username || !$email || !$password) {
         $error = 'Please fill in all required fields.';
     } else {
+        // Create a new account for this admin
+        $stmt = $pdo->prepare("INSERT INTO accounts (name, contact_email) VALUES (?, ?)");
+        $accountName = $username . "'s Theme Park";
+        $stmt->execute([$accountName, $email]);
+        $account_id = $pdo->lastInsertId();
+
         $password_hash = password_hash($password, PASSWORD_BCRYPT);
 
         try {
             $stmt = $pdo->prepare("INSERT INTO users (account_id, role_id, username, email, password_hash) VALUES (?, ?, ?, ?, ?)");
             $stmt->execute([$account_id, $role_id, $username, $email, $password_hash]);
-            $success = 'Welcome to RatPack Park! Your admin account has been created. You can now log in and begin managing your park!';
+
+            $user_id = $pdo->lastInsertId();
+            $stmt = $pdo->prepare("SELECT right_name FROM role_rights WHERE role_id = ?");
+            $stmt->execute([$role_id]);
+            $rights = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+            $payload = [
+                'sub' => $user_id,
+                'username' => $username,
+                'role_id' => $role_id,
+                'account_id' => $account_id,
+                'rights' => $rights,
+                'iat' => time(),
+                'exp' => time() + (60 * 60)
+            ];
+            $jwt = JWT::encode($payload, 'your-secret-key', 'HS256');
+            $_SESSION['jwt'] = $jwt;
+
+            header('Location: dashboard.php');
+            exit;
         } catch (PDOException $e) {
             $error = 'Error: ' . $e->getMessage();
         }

--- a/role_management.php
+++ b/role_management.php
@@ -1,0 +1,100 @@
+<?php
+require 'vendor/autoload.php';
+require 'db.php';
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+session_start();
+$jwt_secret = 'your-secret-key';
+
+if (!isset($_SESSION['jwt'])) {
+    http_response_code(401);
+    echo "Not authenticated";
+    exit;
+}
+
+try {
+    $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
+    $rights = $decoded->rights ?? [];
+} catch (Exception $e) {
+    echo "Invalid session.";
+    exit;
+}
+
+if (!in_array('roles_management', $rights)) {
+    echo "Access denied.";
+    exit;
+}
+
+$error = '';
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'] ?? '';
+    $rights_input = $_POST['rights'] ?? '';
+    if ($name) {
+        $stmt = $pdo->prepare("INSERT INTO roles (name) VALUES (?)");
+        $stmt->execute([$name]);
+        $role_id = $pdo->lastInsertId();
+        $rights_list = array_filter(array_map('trim', explode(',', $rights_input)));
+        foreach ($rights_list as $r) {
+            $stmt = $pdo->prepare("INSERT INTO role_rights (role_id, right_name) VALUES (?, ?)");
+            $stmt->execute([$role_id, $r]);
+        }
+        $success = 'Role created.';
+    } else {
+        $error = 'Name is required.';
+    }
+}
+
+$stmt = $pdo->query("SELECT r.id, r.name, GROUP_CONCAT(rr.right_name ORDER BY rr.right_name SEPARATOR ', ') AS rights FROM roles r LEFT JOIN role_rights rr ON r.id = rr.role_id GROUP BY r.id, r.name ORDER BY r.id");
+$roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Role Management | RatPack Park</title>
+    <style>
+        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
+        h2 { color: #6a1b9a; text-align: center; }
+        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
+        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
+        th { background: #6a1b9a; color: white; }
+        .form-section { background: white; padding: 20px; margin-top: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
+        input, textarea { width: 100%; padding: 10px; margin: 5px 0 10px; border-radius: 5px; border: 1px solid #ccc; }
+        button { padding: 10px 20px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
+        .message { color: green; }
+        .error { color: red; }
+    </style>
+</head>
+<body>
+    <h2>🧩 Role Management</h2>
+    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
+    <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
+
+    <div class="form-section">
+        <h3>Create New Role</h3>
+        <form method="POST">
+            <input type="text" name="name" placeholder="Role name" required>
+            <textarea name="rights" placeholder="Comma-separated rights"></textarea>
+            <button type="submit">Create Role</button>
+        </form>
+    </div>
+
+    <table>
+        <thead>
+            <tr><th>ID</th><th>Name</th><th>Rights</th></tr>
+        </thead>
+        <tbody>
+            <?php foreach ($roles as $role): ?>
+                <tr>
+                    <td><?= htmlspecialchars($role['id']) ?></td>
+                    <td><?= htmlspecialchars($role['name']) ?></td>
+                    <td><?= htmlspecialchars($role['rights'] ?? '') ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/rosters.php
+++ b/rosters.php
@@ -17,8 +17,14 @@ try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
+    exit;
+}
+
+if (!in_array('rosters', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/settings.php
+++ b/settings.php
@@ -1,3 +1,30 @@
+<?php
+require 'vendor/autoload.php';
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+session_start();
+$jwt_secret = 'your-secret-key';
+
+if (!isset($_SESSION['jwt'])) {
+    http_response_code(401);
+    echo "Not authenticated";
+    exit;
+}
+
+try {
+    $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
+    $rights = $decoded->rights ?? [];
+} catch (Exception $e) {
+    echo "Invalid session.";
+    exit;
+}
+
+if (!in_array('settings', $rights)) {
+    echo "Access denied.";
+    exit;
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/ticket_types.php
+++ b/ticket_types.php
@@ -17,13 +17,14 @@ try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id ?? 1;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
     exit;
 }
 
-if ($role_id != 1) {
-    echo "Access denied. Admins only.";
+if (!in_array('settings', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/tickets.php
+++ b/tickets.php
@@ -20,13 +20,14 @@ try {
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id;
     $user_id = $decoded->sub;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
     exit;
 }
 
-if (!in_array($role_id, [1, 2, 3])) {
-    echo "Access denied. Ticket sales staff only.";
+if (!in_array('tickets', $rights)) {
+    echo "Access denied.";
     exit;
 }
 

--- a/user_management.php
+++ b/user_management.php
@@ -17,13 +17,14 @@ try {
     $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
     $role_id = $decoded->role_id;
     $account_id = $decoded->account_id ?? 1;
+    $rights = $decoded->rights ?? [];
 } catch (Exception $e) {
     echo "Invalid session.";
     exit;
 }
 
-if ($role_id != 1) {
-    echo "Access denied. Admins only.";
+if (!in_array('user_management', $rights)) {
+    echo "Access denied.";
     exit;
 }
 
@@ -69,12 +70,11 @@ $stmt->execute([$account_id]);
 $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Role map
-$roles = [
-    1 => 'Admin',
-    2 => 'Manager',
-    3 => 'Ticket Sales',
-    4 => 'Attractions Operator'
-];
+$stmt = $pdo->query("SELECT id, name FROM roles");
+$roles = [];
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $roles[$row['id']] = $row['name'];
+}
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- add maintenance module restricted to admin and manager roles
- show maintenance link in menu for allowed roles
- automatically sign in users after registration
- allow creation of custom roles with database-backed rights and a management page
- embed rights in JWT and render menu items based on permissions

## Testing
- `php -l login.php register.php dashboard.php menu.php maintenance.php analytics.php ticket_types.php tickets.php user_management.php problem.php admin_problem.php my_roster.php rosters.php settings.php role_management.php`


------
https://chatgpt.com/codex/tasks/task_b_6898857f27b883299a4eb51d99b78f6f