### PR TITLE
Add mocked daily operations feature

### DIFF
--- a/daily_operations.php
+++ b/daily_operations.php
@@ -1,0 +1,88 @@
+<?php
+require 'vendor/autoload.php';
+require 'db.php';
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+session_start();
+
+$jwt_secret = 'your-secret-key';
+
+if (!isset($_SESSION['jwt'])) {
+    header('Location: login.php');
+    exit;
+}
+
+try {
+    $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
+    $user_id = $decoded->sub;
+    $rights = $decoded->rights ?? [];
+} catch (Exception $e) {
+    session_destroy();
+    header('Location: login.php');
+    exit;
+}
+
+if (!in_array('daily_operations', $rights)) {
+    echo 'Access denied';
+    exit;
+}
+
+if (!isset($_GET['date'])) {
+    echo '<!DOCTYPE html><html><head><title>Daily Operations</title></head><body>';
+    echo '<script>const d=new Date();const date=d.toLocaleDateString("en-CA");location.href="daily_operations.php?date="+date;</script>';
+    echo '</body></html>';
+    exit;
+}
+
+$operation_date = $_GET['date'];
+
+$stmt = $pdo->prepare("SELECT * FROM daily_operations WHERE user_id = ? AND operation_date = ?");
+$stmt->execute([$user_id, $operation_date]);
+$data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$data) {
+    $stmt = $pdo->prepare("SELECT stock FROM daily_operations WHERE user_id = ? ORDER BY operation_date DESC LIMIT 1");
+    $stmt->execute([$user_id]);
+    $prev_stock = $stmt->fetchColumn();
+    if ($prev_stock === false) {
+        $prev_stock = 100;
+    }
+
+    $guest_count = random_int(50, 200);
+    $weather_options = ['Sunny','Cloudy','Rainy','Stormy','Windy','Snowy'];
+    $weather = $weather_options[array_rand($weather_options)];
+    $incoming_money = $guest_count * random_int(20, 50);
+    $outgoing_money = random_int(100, 500);
+    $stock_change = random_int(-10, 10);
+    $stock = max(0, $prev_stock + $stock_change);
+
+    $stmt = $pdo->prepare("INSERT INTO daily_operations (user_id, operation_date, guest_count, weather, incoming_money, outgoing_money, stock) VALUES (?,?,?,?,?,?,?)");
+    $stmt->execute([$user_id, $operation_date, $guest_count, $weather, $incoming_money, $outgoing_money, $stock]);
+
+    $data = [
+        'guest_count' => $guest_count,
+        'weather' => $weather,
+        'incoming_money' => $incoming_money,
+        'outgoing_money' => $outgoing_money,
+        'stock' => $stock
+    ];
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Daily Operations</title>
+</head>
+<body>
+<h2>Daily Operations for <?php echo htmlspecialchars($operation_date); ?></h2>
+<ul>
+    <li>Guest count: <?php echo htmlspecialchars($data['guest_count']); ?></li>
+    <li>Weather: <?php echo htmlspecialchars($data['weather']); ?></li>
+    <li>Incoming money: $<?php echo htmlspecialchars(number_format($data['incoming_money'], 2)); ?></li>
+    <li>Outgoing money: $<?php echo htmlspecialchars(number_format($data['outgoing_money'], 2)); ?></li>
+    <li>Stock: <?php echo htmlspecialchars($data['stock']); ?></li>
+</ul>
+</body>
+</html>

--- a/init.sql
+++ b/init.sql
@@ -145,6 +145,7 @@ INSERT INTO `role_rights` (`role_id`, `right_name`) VALUES
 (1, 'user_management'),
 (1, 'roles_management'),
 (1, 'logout'),
+(1, 'daily_operations'),
 (2, 'rosters'),
 (2, 'tickets'),
 (2, 'my_roster'),
@@ -259,6 +260,23 @@ INSERT INTO `users` (`id`, `account_id`, `role_id`, `username`, `email`, `passwo
 (7, 1, 4, 'low', 'low@thexssrat.com', '$2y$10$XN5axlfiLHkmoAVm0jPy6uWrxZ0OyY1E9JPKSlpDKQA.Bvp4BTAFm', '2025-07-15 13:45:32'),
 (8, 1, 2, 'man', 'man@thexss.com', '$2y$10$Mljoo5mQo8zxd5hI0eu60usZPGdPBfcaV.dRWslSb215DP4FS6TWm', '2025-07-15 13:46:54');
 
+-- --------------------------------------------------------
+
+-- Table structure for table `daily_operations`
+--
+
+CREATE TABLE `daily_operations` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `operation_date` date NOT NULL,
+  `guest_count` int(11) DEFAULT NULL,
+  `weather` varchar(50) DEFAULT NULL,
+  `incoming_money` decimal(10,2) DEFAULT NULL,
+  `outgoing_money` decimal(10,2) DEFAULT NULL,
+  `stock` int(11) DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 --
 -- Indexen voor geëxporteerde tabellen
 --
@@ -329,6 +347,12 @@ ALTER TABLE `users`
   ADD KEY `account_id` (`account_id`),
   ADD KEY `role_id` (`role_id`);
 
+-- Indexen voor tabel `daily_operations`
+ALTER TABLE `daily_operations`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `user_id_operation_date` (`user_id`,`operation_date`),
+  ADD KEY `user_id` (`user_id`);
+
 --
 -- AUTO_INCREMENT voor geëxporteerde tabellen
 --
@@ -381,6 +405,11 @@ ALTER TABLE `tickets`
 ALTER TABLE `users`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=9;
 
+-- AUTO_INCREMENT voor een tabel `daily_operations`
+--
+ALTER TABLE `daily_operations`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
 --
 -- Beperkingen voor geëxporteerde tabellen
 --
@@ -424,6 +453,10 @@ ALTER TABLE `tickets`
 ALTER TABLE `users`
   ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`);
+
+-- Beperkingen voor tabel `daily_operations`
+ALTER TABLE `daily_operations`
+  ADD CONSTRAINT `daily_operations_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
 
 --
 -- Beperkingen voor tabel `role_rights`

--- a/menu.php
+++ b/menu.php
@@ -10,6 +10,7 @@ $menu_items = [
     ['label' => 'Report a problem', 'url' => 'problem.php', 'rights' => ['report_problem']],
     ['label' => 'Admin problem overview', 'url' => 'admin_problem.php', 'rights' => ['admin_problem']],
     ['label' => 'Role Management', 'url' => 'role_management.php', 'rights' => ['roles_management']],
+    ['label' => 'Daily Operations', 'url' => 'daily_operations.php', 'rights' => ['daily_operations']],
     ['label' => 'Logout', 'url' => 'logout.php', 'rights' => ['logout']],
 ];
 


### PR DESCRIPTION
## Summary
- add daily operations page that generates mock metrics using user local date and builds on previous records
- create supporting table and permission in database seed
- expose daily operations in the sidebar menu

## Testing
- `php -l daily_operations.php`
- `php -l menu.php`


------
https://chatgpt.com/codex/tasks/task_b_6898cc0a6e6083299a050e456b32857b