### PR TITLE
Gamify Rat Track hunts with scoreboard and fresh targets

### DIFF
--- a/admin_problem.php
+++ b/admin_problem.php
@@ -1,6 +1,7 @@
 <?php
 require 'vendor/autoload.php';
 require 'db.php';
+require_once 'rat_helpers.php';
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 
@@ -40,6 +41,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['report_id'], $_POST['
 $stmt = $pdo->prepare("SELECT pr.id, u.username, pr.category, pr.description, pr.status, pr.submitted_at FROM problem_reports pr JOIN users u ON pr.submitted_by = u.id WHERE pr.account_id = ? ORDER BY pr.submitted_at DESC");
 $stmt->execute([$account_id]);
 $reports = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$notes_problem_meta = null;
+$notes_for_problem = [];
+$notes_missing = false;
+if (isset($_GET['notes'])) {
+    $notes_id = (int)$_GET['notes'];
+    if ($notes_id > 0) {
+        $metaStmt = $pdo->prepare("SELECT pr.*, u.username FROM problem_reports pr LEFT JOIN users u ON pr.submitted_by = u.id WHERE pr.id = ?");
+        $metaStmt->execute([$notes_id]);
+        $notes_problem_meta = $metaStmt->fetch(PDO::FETCH_ASSOC);
+        if ($notes_problem_meta) {
+            if ((int)$notes_problem_meta['account_id'] !== (int)$account_id) {
+                rat_track_add_score_event('IDOR', 'Viewed maintenance notes for another tenant');
+            }
+            $notesStmt = $pdo->prepare("SELECT pn.note, pn.created_at, au.username FROM problem_notes pn LEFT JOIN users au ON pn.author_id = au.id WHERE pn.problem_id = ? ORDER BY pn.created_at ASC");
+            $notesStmt->execute([$notes_id]);
+            $notes_for_problem = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
+        } else {
+            $notes_missing = true;
+        }
+    }
+}
 ?>
 
 <!DOCTYPE html>
@@ -52,17 +75,40 @@ $reports = $stmt->fetchAll(PDO::FETCH_ASSOC);
         .container { background: white; padding: 20px; border-radius: 10px; max-width: 900px; margin: auto; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
         h2 { color: #6a1b9a; text-align: center; }
         .message { color: green; text-align: center; }
+        .error { color: #d32f2f; text-align: center; }
         table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.05); margin-top: 20px; }
         th, td { padding: 10px; border-bottom: 1px solid #ccc; text-align: left; vertical-align: top; }
         th { background: #6a1b9a; color: white; }
         form.inline-form { display: flex; gap: 6px; align-items: center; }
         select, button { padding: 6px; border-radius: 4px; border: 1px solid #999; }
+        .notes-card { margin-top: 20px; background: #e8eaf6; padding: 18px; border-radius: 12px; }
+        .notes-card h3 { margin-top: 0; color: #303f9f; }
+        .notes-card ul { list-style: disc; padding-left: 20px; color: #1a237e; }
+        .notes-card li { margin: 6px 0; }
+        .notes-empty { color: #555; }
     </style>
 </head>
 <body>
     <div class="container">
         <h2>📊 Admin Problem Management</h2>
         <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
+        <?php if ($notes_problem_meta): ?>
+            <div class="notes-card">
+                <h3>🗒️ Notes for Incident #<?= htmlspecialchars($notes_problem_meta['id']) ?> (Tenant <?= htmlspecialchars((string)$notes_problem_meta['account_id']); ?>)</h3>
+                <p><strong>Category:</strong> <?= htmlspecialchars($notes_problem_meta['category']); ?> | <strong>Status:</strong> <?= htmlspecialchars($notes_problem_meta['status']); ?></p>
+                <ul>
+                    <?php if (!empty($notes_for_problem)): ?>
+                        <?php foreach ($notes_for_problem as $note): ?>
+                            <li><strong><?= htmlspecialchars($note['username'] ?? 'Unknown') ?>:</strong> <?= htmlspecialchars($note['note']); ?> <em>(<?= htmlspecialchars($note['created_at']); ?>)</em></li>
+                        <?php endforeach; ?>
+                    <?php else: ?>
+                        <li class="notes-empty">No notes recorded for this problem.</li>
+                    <?php endif; ?>
+                </ul>
+            </div>
+        <?php elseif ($notes_missing): ?>
+            <p class="error">No problem record exists for that ID.</p>
+        <?php endif; ?>
         <table>
             <thead>
                 <tr>
@@ -99,5 +145,7 @@ $reports = $stmt->fetchAll(PDO::FETCH_ASSOC);
             </tbody>
         </table>
     </div>
+    <script src="rat_scoreboard.js"></script>
+    <?php include 'partials/score_event.php'; ?>
 </body>
 </html>

--- a/dashboard.php
+++ b/dashboard.php
@@ -61,6 +61,17 @@ try {
             background: #4a148c;
             color: white;
             padding: 10px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .topbar a {
+            color: #ffeb3b;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .topbar a:hover {
+            text-decoration: underline;
         }
         iframe {
             flex: 1;
@@ -76,9 +87,12 @@ try {
     </div>
     <div class="main">
         <div class="topbar">
-            Logged in as <strong><?php echo htmlspecialchars($username); ?></strong> | Role ID: <?php echo $role_id; ?>
+            <span>Logged in as <strong><?php echo htmlspecialchars($username); ?></strong> | Role ID: <?php echo $role_id; ?></span>
+            <a href="https://www.youtube.com/playlist?list=PLd92v1QxPOprxnqslA9ho9egWvs4_3gDQ" target="_blank" rel="noopener noreferrer">Solutions</a>
         </div>
         <iframe name="mainframe" src="welcome.php"></iframe>
     </div>
+    <script src="rat_scoreboard.js"></script>
+    <?php include 'partials/score_event.php'; ?>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -26,6 +26,24 @@ use Firebase\JWT\Key;
             box-shadow: 0 8px 20px rgba(0,0,0,0.1);
             text-align: center;
         }
+        .guide {
+            margin: 30px 0;
+            text-align: left;
+            background: #f8f3ff;
+            border-radius: 12px;
+            padding: 20px 24px;
+            box-shadow: inset 0 0 0 1px rgba(106, 27, 154, 0.12);
+        }
+        .guide h2 {
+            color: #4a148c;
+            margin-top: 0;
+        }
+        .guide ol {
+            margin: 0;
+            padding-left: 20px;
+            color: #444;
+            line-height: 1.6;
+        }
         h1 {
             color: #6a1b9a;
         }
@@ -55,6 +73,16 @@ use Firebase\JWT\Key;
             Manage your entire theme park effortlessly. From shift rosters to ticket sales, we've got it covered.<br>
             Try it now and see how it transforms your operations.
         </p>
+        <div class="guide">
+            <h2>How the Platform Fits Together</h2>
+            <ol>
+                <li><strong>Create your organisation:</strong> Register a trial account to generate a brand new tenant with an administrator user.</li>
+                <li><strong>Invite and schedule your crew:</strong> Configure ticket types and discounts, create staff through User Management, and arrange their shifts within Rosters.</li>
+                <li><strong>Operate the park:</strong> Track daily metrics in Daily Operations, sell tickets, and watch revenue update automatically.</li>
+                <li><strong>Stay on top of issues:</strong> Log incidents from the Report Problem area and triage them through the Admin Problem view.</li>
+                <li><strong>Review performance:</strong> Visit Analytics for tenant-wide KPIs and Rat Track to study known weaknesses and challenges.</li>
+            </ol>
+        </div>
         <a class="button" href="register.php">Start Free Trial</a>
         <a class="button" href="login.php">Already a Member? Log In</a>
     </div>

--- a/menu.php
+++ b/menu.php
@@ -13,6 +13,7 @@ $menu_items = [
     ['label' => 'Role Management', 'url' => 'role_management.php', 'rights' => ['roles_management']],
     ['label' => 'Assign Roles', 'url' => 'assign_roles.php', 'rights' => ['user_management']],
     ['label' => 'Daily Operations', 'url' => 'daily_operations.php', 'rights' => ['daily_operations']],
+    ['label' => 'Rat Track', 'url' => 'rat_track.php', 'rights' => ['logout']],
     ['label' => 'Logout', 'url' => 'logout.php', 'rights' => ['logout']],
 ];
 

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -2,6 +2,10 @@
     Please log a ticket in case of a problem with this lab:
     <a href="mailto:ser@thexssrat.atlassian.net">ser@thexssrat.atlassian.net</a> - or via our helpdesk portal
     <a href="https://thexssrat.atlassian.net/servicedesk/customer/portal/4">https://thexssrat.atlassian.net/servicedesk/customer/portal/4</a>
+    |
+    <a href="https://www.youtube.com/playlist?list=PLd92v1QxPOprxnqslA9ho9egWvs4_3gDQ" target="_blank" rel="noopener noreferrer">Solutions</a>
 </footer>
+<script src="rat_scoreboard.js"></script>
+<?php include __DIR__ . '/score_event.php'; ?>
 </body>
 </html>

--- a/partials/header.php
+++ b/partials/header.php
@@ -11,6 +11,20 @@
             margin: 0;
             padding: 0;
         }
+        .global-banner {
+            background: rgba(74, 20, 140, 0.9);
+            color: #fff;
+            padding: 8px 16px;
+            text-align: right;
+        }
+        .global-banner a {
+            color: #ffeb3b;
+            font-weight: 600;
+            text-decoration: none;
+        }
+        .global-banner a:hover {
+            text-decoration: underline;
+        }
         .form-container {
             background-color: #ffffffdd;
             padding: 2em;
@@ -40,4 +54,7 @@
     </style>
 </head>
 <body>
+<div class="global-banner">
+    <a href="https://www.youtube.com/playlist?list=PLd92v1QxPOprxnqslA9ho9egWvs4_3gDQ" target="_blank" rel="noopener noreferrer">Solutions</a>
+</div>
 <!-- 'your-secret-key' should be replaced with your actual JWT secret key -->

--- a/partials/score_event.php
+++ b/partials/score_event.php
@@ -1,0 +1,10 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    return;
+}
+if (empty($_SESSION['rat_score_events']) || !is_array($_SESSION['rat_score_events'])) {
+    return;
+}
+$events = array_values($_SESSION['rat_score_events']);
+unset($_SESSION['rat_score_events']);
+echo '<script>window.__ratQueueScoreEvents(' . json_encode($events, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) . ');</script>';

--- a/rat_helpers.php
+++ b/rat_helpers.php
@@ -1,0 +1,18 @@
+<?php
+if (!function_exists('rat_track_add_score_event')) {
+    function rat_track_add_score_event(string $type, string $message, int $points = 1): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (!isset($_SESSION['rat_score_events']) || !is_array($_SESSION['rat_score_events'])) {
+            $_SESSION['rat_score_events'] = [];
+        }
+        $_SESSION['rat_score_events'][] = [
+            'type' => $type,
+            'message' => $message,
+            'points' => $points,
+            'ts' => time(),
+        ];
+    }
+}

--- a/rat_scoreboard.js
+++ b/rat_scoreboard.js
@@ -1,0 +1,249 @@
+(function () {
+    if (window.__ratScoreboardLoaded) {
+        return;
+    }
+    window.__ratScoreboardLoaded = true;
+
+    const SCORE_KEY = 'ratTrackScore';
+    const MAX_KEY = 'ratTrackMaxScore';
+    const pendingQueue = Array.isArray(window.__ratScoreboardQueue) ? window.__ratScoreboardQueue : [];
+    let container;
+    let scoreValue;
+    let maxValue;
+    let lastEvent;
+    let lastEventWrapper;
+
+    function readStorage(key) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch (err) {
+            return null;
+        }
+    }
+
+    function writeStorage(key, value) {
+        try {
+            window.localStorage.setItem(key, String(value));
+        } catch (err) {
+            // ignore storage issues (e.g. Safari private mode)
+        }
+    }
+
+    function injectStyles() {
+        if (document.getElementById('rat-scoreboard-style')) {
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'rat-scoreboard-style';
+        style.textContent = `
+            #rat-scoreboard {
+                position: fixed;
+                top: 16px;
+                right: 16px;
+                z-index: 2147483647;
+                background: rgba(51, 16, 88, 0.92);
+                color: #f9f5ff;
+                border-radius: 12px;
+                padding: 16px 18px;
+                width: 240px;
+                box-shadow: 0 12px 32px rgba(44, 0, 90, 0.35);
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                backdrop-filter: blur(6px);
+            }
+            #rat-scoreboard.rat-scoreboard-new-max {
+                animation: ratScorePulse 1.2s ease;
+            }
+            #rat-scoreboard .rat-scoreboard-title {
+                font-size: 16px;
+                font-weight: 700;
+                letter-spacing: 0.05em;
+                margin-bottom: 12px;
+                text-transform: uppercase;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+            #rat-scoreboard .rat-scoreboard-title span {
+                font-size: 14px;
+                font-weight: 600;
+                background: rgba(255, 255, 255, 0.15);
+                border-radius: 999px;
+                padding: 4px 8px;
+            }
+            #rat-scoreboard .rat-scoreboard-metric {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-bottom: 6px;
+                font-size: 15px;
+            }
+            #rat-scoreboard .rat-scoreboard-metric strong {
+                font-size: 20px;
+            }
+            #rat-scoreboard .rat-scoreboard-last {
+                margin-top: 12px;
+                font-size: 13px;
+                line-height: 1.4;
+                background: rgba(255, 255, 255, 0.12);
+                padding: 10px;
+                border-radius: 10px;
+                min-height: 44px;
+                transition: background 0.3s ease, transform 0.3s ease;
+            }
+            #rat-scoreboard .rat-scoreboard-last.rat-scoreboard-highlight {
+                background: rgba(103, 58, 183, 0.55);
+                transform: translateY(-2px);
+            }
+            #rat-scoreboard .rat-scoreboard-max-label {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+            }
+            #rat-scoreboard .rat-scoreboard-max-label span {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                font-size: 12px;
+                padding: 2px 8px;
+                border-radius: 999px;
+                background: rgba(255, 255, 255, 0.18);
+            }
+            #rat-scoreboard .rat-scoreboard-footer {
+                margin-top: 10px;
+                font-size: 11px;
+                opacity: 0.75;
+                text-align: right;
+            }
+            @keyframes ratScorePulse {
+                0% { box-shadow: 0 0 0 rgba(255, 255, 255, 0.0); }
+                35% { box-shadow: 0 0 18px rgba(255, 193, 7, 0.55); }
+                100% { box-shadow: 0 0 0 rgba(255, 255, 255, 0.0); }
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    function createContainer() {
+        const el = document.createElement('div');
+        el.id = 'rat-scoreboard';
+        el.innerHTML = `
+            <div class="rat-scoreboard-title">Rat Track <span>Scoreboard</span></div>
+            <div class="rat-scoreboard-metric">
+                <span>Current Score</span>
+                <strong data-rat-score>0</strong>
+            </div>
+            <div class="rat-scoreboard-metric">
+                <span class="rat-scoreboard-max-label">Best Run<span>🏆</span></span>
+                <strong data-rat-max>0</strong>
+            </div>
+            <div class="rat-scoreboard-last" data-rat-last>Explore the app to unlock findings.</div>
+            <div class="rat-scoreboard-footer">Find IDORs &amp; BAC to climb the board.</div>
+        `;
+        scoreValue = el.querySelector('[data-rat-score]');
+        maxValue = el.querySelector('[data-rat-max]');
+        lastEvent = el.querySelector('[data-rat-last]');
+        lastEventWrapper = lastEvent;
+        return el;
+    }
+
+    const scoreboard = {
+        ready: false,
+        score: 0,
+        max: 0,
+        queue: pendingQueue,
+        init() {
+            injectStyles();
+            container = createContainer();
+            document.body.appendChild(container);
+            const storedScore = parseInt(readStorage(SCORE_KEY), 10);
+            const storedMax = parseInt(readStorage(MAX_KEY), 10);
+            this.score = Number.isFinite(storedScore) ? storedScore : 0;
+            this.max = Number.isFinite(storedMax) ? storedMax : 0;
+            this.ready = true;
+            this.updateUI();
+            if (Array.isArray(this.queue) && this.queue.length) {
+                const copy = this.queue.slice();
+                this.queue.length = 0;
+                copy.forEach((event) => this.addEvent(event));
+            }
+            window.__ratScoreboardQueue = this.queue;
+        },
+        addEvent(event) {
+            if (!event) {
+                return;
+            }
+            if (!this.ready) {
+                this.queue.push(event);
+                return;
+            }
+            const numericPoints = Number(event.points);
+            const points = Number.isFinite(numericPoints) && numericPoints > 0 ? numericPoints : 1;
+            this.score += points;
+            if (this.score > this.max) {
+                this.max = this.score;
+                writeStorage(MAX_KEY, this.max);
+                if (container) {
+                    container.classList.remove('rat-scoreboard-new-max');
+                    void container.offsetWidth;
+                    container.classList.add('rat-scoreboard-new-max');
+                }
+            }
+            writeStorage(SCORE_KEY, this.score);
+            this.updateUI(event);
+        },
+        updateUI(lastEventData) {
+            if (scoreValue) {
+                scoreValue.textContent = String(this.score);
+            }
+            if (maxValue) {
+                maxValue.textContent = String(this.max);
+            }
+            if (lastEventWrapper) {
+                if (lastEventData) {
+                    const summary = lastEventData.type ? `${lastEventData.type}: ${lastEventData.message}` : lastEventData.message;
+                    lastEventWrapper.textContent = summary || 'New activity recorded.';
+                    lastEventWrapper.classList.add('rat-scoreboard-highlight');
+                    setTimeout(() => {
+                        lastEventWrapper.classList.remove('rat-scoreboard-highlight');
+                    }, 1200);
+                    lastEventWrapper.dataset.hadEvent = '1';
+                } else if (!lastEventWrapper.dataset.hadEvent) {
+                    lastEventWrapper.textContent = 'Explore the app to unlock findings.';
+                }
+            }
+        },
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        scoreboard.init();
+    });
+
+    window.ratScoreboard = {
+        addEvent(event) {
+            scoreboard.addEvent(event);
+        },
+        pushEvents(events) {
+            if (!Array.isArray(events)) {
+                return;
+            }
+            events.forEach((event) => scoreboard.addEvent(event));
+        },
+        getState() {
+            return { score: scoreboard.score, max: scoreboard.max };
+        },
+    };
+
+    window.__ratQueueScoreEvents = function (events) {
+        if (!Array.isArray(events) || !events.length) {
+            return;
+        }
+        if (window.ratScoreboard && typeof window.ratScoreboard.pushEvents === 'function') {
+            window.ratScoreboard.pushEvents(events);
+        } else {
+            window.__ratScoreboardQueue = window.__ratScoreboardQueue || [];
+            window.__ratScoreboardQueue = window.__ratScoreboardQueue.concat(events);
+        }
+    };
+
+    window.__ratScoreboardQueue = pendingQueue;
+})();

--- a/rat_track.php
+++ b/rat_track.php
@@ -1,0 +1,234 @@
+<?php
+require 'vendor/autoload.php';
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+session_start();
+$jwt_secret = 'your-secret-key';
+
+if (!isset($_SESSION['jwt'])) {
+    http_response_code(401);
+    echo 'Not authenticated';
+    exit;
+}
+
+try {
+    $decoded = JWT::decode($_SESSION['jwt'], new Key($jwt_secret, 'HS256'));
+    $rights = $decoded->rights ?? [];
+} catch (Exception $e) {
+    http_response_code(401);
+    echo 'Invalid session.';
+    exit;
+}
+
+if (!in_array('logout', $rights)) {
+    echo 'Access denied.';
+    exit;
+}
+
+$vulnerabilities = [
+    [
+        'category' => 'IDOR, Inter-tenant IDOR',
+        'endpoint' => 'rosters.php',
+        'title' => 'Shift deletion lacks tenant scoping',
+        'details' => 'The delete handler issues <code>DELETE FROM shifts WHERE id = ?</code> without confirming the shift belongs to the current account.',
+        'exploit' => 'Send <code>rosters.php?delete=&lt;target_shift_id&gt;</code> to remove schedules that belong to other tenants.'
+    ],
+    [
+        'category' => 'IDOR, Inter-tenant IDOR',
+        'endpoint' => 'rosters.php',
+        'title' => 'Shift edits trust arbitrary IDs',
+        'details' => 'Update requests run <code>UPDATE shifts SET ... WHERE id = ?</code> without validating account ownership.',
+        'exploit' => 'Submit the edit form with a forged <code>edit_shift_id</code> to overwrite another tenant’s roster entry.'
+    ],
+    [
+        'category' => 'IDOR, Inter-tenant IDOR',
+        'endpoint' => 'rosters.php',
+        'title' => 'Shift creation accepts foreign user IDs',
+        'details' => 'The create handler inserts whatever <code>user_id</code> is supplied, even if it points to a user from another account.',
+        'exploit' => 'Post a crafted <code>create_shift</code> request with a victim account user ID to assign them bogus duties.'
+    ],
+    [
+        'category' => 'IDOR, Inter-tenant IDOR',
+        'endpoint' => 'special_discounts.php',
+        'title' => 'Discount creation is missing tenant checks',
+        'details' => 'Discounts are inserted via <code>INSERT INTO ticket_discounts (ticket_id,...)</code> without verifying that the ticket belongs to the active tenant.',
+        'exploit' => 'Craft a <code>create_discount</code> POST pointing at another tenant’s <code>ticket_id</code> to force their discounts.'
+    ],
+    [
+        'category' => 'IDOR, Inter-tenant IDOR',
+        'endpoint' => 'special_discounts.php',
+        'title' => 'Discount deletion trusts the id parameter',
+        'details' => 'The delete endpoint executes <code>DELETE FROM ticket_discounts WHERE id = ?</code> with no tenant scoping.',
+        'exploit' => 'Calling <code>special_discounts.php?delete=&lt;victim_discount_id&gt;</code> removes offers from other tenants.'
+    ],
+    [
+        'category' => 'IDOR, Inter-tenant IDOR',
+        'endpoint' => 'tickets.php',
+        'title' => 'Ticket purchases are not account scoped',
+        'details' => 'Ticket sales subtract stock using <code>UPDATE tickets SET available_quantity = available_quantity - ? WHERE id = ?</code> without checking <code>account_id</code>.',
+        'exploit' => 'Forge a <code>buy_ticket</code> POST that references a different tenant’s ticket ID to drain or replenish their inventory.'
+    ],
+    [
+        'category' => 'BAC',
+        'endpoint' => 'tickets.php',
+        'title' => 'Negative quantities boost inventory',
+        'details' => 'No server-side validation prevents negative quantities, so the subtraction query increases stock and still logs a sale.',
+        'exploit' => 'Submit <code>quantity=-10</code> in the buy flow to add tickets back into inventory illegitimately.'
+    ],
+    [
+        'category' => 'BAC',
+        'endpoint' => 'daily_operations.php',
+        'title' => 'Revenue totals leak multi-tenant data',
+        'details' => '<code>getSalesData()</code> sums sales joined to tickets without filtering by account, so other tenants’ revenue is revealed.',
+        'exploit' => 'View any day and the dashboard includes sales from every tenant in the shared database.'
+    ],
+    [
+        'category' => 'IDOR',
+        'endpoint' => 'tickets.php',
+        'title' => 'Ticket inspection reveals competitors',
+        'details' => 'The optional <code>?inspect=</code> helper pulls ticket metadata solely by primary key with no account filter.',
+        'exploit' => 'Browse to <code>tickets.php?inspect=&lt;victim_ticket_id&gt;</code> to read names, prices and stock for another tenant.'
+    ],
+    [
+        'category' => 'IDOR',
+        'endpoint' => 'problem.php',
+        'title' => 'Incident viewer discloses foreign reports',
+        'details' => 'Supplying <code>?view=</code> fetches any <code>problem_reports</code> row without checking <code>account_id</code> or reporter.',
+        'exploit' => 'Call <code>problem.php?view=&lt;target_report_id&gt;</code> to see descriptions and attachments from other tenants.'
+    ],
+    [
+        'category' => 'IDOR',
+        'endpoint' => 'admin_problem.php',
+        'title' => 'Problem note audit lacks tenant scoping',
+        'details' => 'The <code>?notes=</code> audit feed joins into <code>problem_notes</code> by id alone, exposing other teams’ maintenance discussion.',
+        'exploit' => 'Load <code>admin_problem.php?notes=&lt;target_problem_id&gt;</code> to enumerate remediation notes outside your estate.'
+    ],
+    [
+        'category' => 'IDOR',
+        'endpoint' => 'analytics.php',
+        'title' => 'Analytics trust caller-supplied account IDs',
+        'details' => 'When <code>?account=</code> is present the query swaps in that value, returning KPI counts for whichever tenant ID you provide.',
+        'exploit' => 'Abuse <code>analytics.php?account=1</code> from another tenant to read Fantasy Kingdom’s user and ticket totals.'
+    ],
+    [
+        'category' => 'IDOR',
+        'endpoint' => 'daily_operations.php',
+        'title' => 'Daily operations expose cross-tenant revenue filters',
+        'details' => 'Adding <code>?account=</code> selects a tenant id for revenue math, letting you peek at any park’s guest and income totals.',
+        'exploit' => 'Request <code>daily_operations.php?date=&lt;day&gt;&amp;account=&lt;victim_id&gt;</code> to pivot the dashboard to another tenant.'
+    ],
+    [
+        'category' => 'BAC',
+        'endpoint' => 'daily_operations.php',
+        'title' => 'Income override endpoint grants unlimited cash',
+        'details' => 'The hidden override form updates <code>incoming_money</code> with whatever value is submitted—no role, limit, or integrity checks.',
+        'exploit' => 'POST <code>override_income_value=999999</code> to <code>daily_operations.php</code> to inflate today’s revenue instantly.'
+    ],
+    [
+        'category' => 'BAC, IDOR',
+        'endpoint' => 'tickets.php',
+        'title' => 'Raw sales audit spills global transactions',
+        'details' => 'Enabling <code>?sales_audit=1</code> dumps every <code>sales</code> record and joins tickets without verifying <code>account_id</code>.',
+        'exploit' => 'Use <code>tickets.php?sales_audit=1</code> to enumerate all buyer activity across tenants.'
+    ],
+];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Rat Track | RatPack Park</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f3e5f5;
+            margin: 0;
+            padding: 20px;
+        }
+        h1 {
+            text-align: center;
+            color: #6a1b9a;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+            box-shadow: 0 0 12px rgba(0,0,0,0.1);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        thead {
+            background: #6a1b9a;
+            color: #fff;
+        }
+        th, td {
+            padding: 14px 16px;
+            border-bottom: 1px solid #e0e0e0;
+            vertical-align: top;
+        }
+        tr:last-child td {
+            border-bottom: none;
+        }
+        tbody tr:nth-child(even) {
+            background: #f8f5fc;
+        }
+        a.endpoint-link {
+            color: #4a148c;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        a.endpoint-link:hover {
+            text-decoration: underline;
+        }
+        .category-tag {
+            display: inline-block;
+            background: #ede7f6;
+            color: #4a148c;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            margin: 2px 4px 2px 0;
+        }
+        .notes {
+            font-size: 14px;
+            color: #444;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <h1>Rat Track</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Category</th>
+                <th>Endpoint</th>
+                <th>Issue</th>
+                <th>Details &amp; Exploitation</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($vulnerabilities as $entry): ?>
+                <tr>
+                    <td>
+                        <?php foreach (explode(',', $entry['category']) as $tag): ?>
+                            <span class="category-tag"><?php echo htmlspecialchars(trim($tag)); ?></span>
+                        <?php endforeach; ?>
+                    </td>
+                    <td>
+                        <a class="endpoint-link" href="<?php echo htmlspecialchars($entry['endpoint']); ?>" target="mainframe"><?php echo htmlspecialchars($entry['endpoint']); ?></a>
+                    </td>
+                    <td><?php echo htmlspecialchars($entry['title']); ?></td>
+                    <td class="notes">
+                        <div><?php echo $entry['details']; ?></div>
+                        <div><strong>How to exploit:</strong> <?php echo $entry['exploit']; ?></div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <script src="rat_scoreboard.js"></script>
+    <?php include 'partials/score_event.php'; ?>
+</body>
+</html>

--- a/tickets.php
+++ b/tickets.php
@@ -1,6 +1,7 @@
 <?php
 require 'vendor/autoload.php';
 require 'db.php';
+require_once 'rat_helpers.php';
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 ini_set('display_errors', 1);
@@ -35,6 +36,17 @@ if (isset($_POST['buy_ticket'])) {
     $ticket_id = (int)$_POST['ticket_id'];
     $quantity = (int)$_POST['quantity'];
 
+    if ($quantity < 0) {
+        rat_track_add_score_event('BAC', 'Used negative ticket quantity to restock inventory');
+    }
+
+    $ticketOwnerStmt = $pdo->prepare("SELECT account_id FROM tickets WHERE id = ?");
+    $ticketOwnerStmt->execute([$ticket_id]);
+    $ticketAccount = $ticketOwnerStmt->fetchColumn();
+    if ($ticketAccount !== false && (int)$ticketAccount !== (int)$account_id) {
+        rat_track_add_score_event('IDOR', 'Manipulated another tenant’s ticket inventory');
+    }
+
     // Reduce available_quantity
     $stmt = $pdo->prepare("UPDATE tickets SET available_quantity = available_quantity - ? WHERE id = ? AND available_quantity >= ?");
     $stmt->execute([$quantity, $ticket_id, $quantity]);
@@ -59,6 +71,33 @@ foreach ($tickets as &$ticket) {
     }
 }
 unset($ticket);
+
+$inspected_ticket = null;
+$inspection_missing = false;
+if (isset($_GET['inspect'])) {
+    $inspect_id = (int)$_GET['inspect'];
+    if ($inspect_id > 0) {
+        $inspectStmt = $pdo->prepare("SELECT t.*, a.name AS account_name FROM tickets t LEFT JOIN accounts a ON t.account_id = a.id WHERE t.id = ?");
+        $inspectStmt->execute([$inspect_id]);
+        $inspected_ticket = $inspectStmt->fetch(PDO::FETCH_ASSOC);
+        if ($inspected_ticket && (int)$inspected_ticket['account_id'] !== (int)$account_id) {
+            rat_track_add_score_event('IDOR', 'Inspected another tenant’s ticket catalog');
+        }
+        if (!$inspected_ticket) {
+            $inspection_missing = true;
+        }
+    }
+}
+
+$sales_audit_rows = [];
+if (isset($_GET['sales_audit']) && (int)$_GET['sales_audit'] === 1) {
+    $auditStmt = $pdo->prepare("SELECT s.id, s.sale_date, s.quantity, u.username, t.name AS ticket_name, t.account_id FROM sales s LEFT JOIN users u ON s.user_id = u.id LEFT JOIN tickets t ON s.ticket_id = t.id ORDER BY s.sale_date DESC");
+    $auditStmt->execute();
+    $sales_audit_rows = $auditStmt->fetchAll(PDO::FETCH_ASSOC);
+    if (!empty($sales_audit_rows)) {
+        rat_track_add_score_event('IDOR', 'Dumped every tenant’s ticket sales history');
+    }
+}
 ?>
 
 <!DOCTYPE html>
@@ -76,12 +115,70 @@ unset($ticket);
         button { padding: 6px 10px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
         .message { color: green; }
         .error { color: red; }
+        .inspect-card {
+            margin-top: 20px;
+            padding: 18px 20px;
+            background: #fff8e1;
+            border-radius: 10px;
+            box-shadow: 0 6px 20px rgba(255, 152, 0, 0.15);
+        }
+        .inspect-card h3 {
+            margin: 0 0 10px;
+            color: #ff6f00;
+        }
+        .inspect-card p {
+            margin: 4px 0;
+        }
+        .hint {
+            margin-top: 12px;
+            font-size: 12px;
+            color: #444;
+        }
+        .audit-heading {
+            margin-top: 40px;
+            color: #4a148c;
+            text-align: left;
+        }
+        .audit-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 10px;
+            background: white;
+            box-shadow: 0 0 12px rgba(0,0,0,0.08);
+        }
+        .audit-table th, .audit-table td {
+            padding: 10px 12px;
+            border-bottom: 1px solid #ddd;
+            font-size: 14px;
+        }
+        .audit-table th {
+            background: #4a148c;
+            color: #fff;
+        }
+        .audit-table tr:nth-child(even) {
+            background: #f7f1ff;
+        }
+        .audit-table tr.cross-tenant {
+            background: rgba(244, 67, 54, 0.12);
+        }
     </style>
 </head>
 <body>
     <h2>🎟️ Available Tickets</h2>
     <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
     <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
+
+    <?php if ($inspected_ticket): ?>
+        <div class="inspect-card">
+            <h3>🔍 Ticket Insight</h3>
+            <p><strong><?= htmlspecialchars($inspected_ticket['name']) ?></strong> (Ticket ID #<?= htmlspecialchars($inspected_ticket['id']) ?>)</p>
+            <p>Account: <?= htmlspecialchars($inspected_ticket['account_name'] ?? 'Unknown') ?> (ID #<?= htmlspecialchars($inspected_ticket['account_id'] ?? 'N/A') ?>)</p>
+            <p>Face value: &euro;<?= number_format((float)$inspected_ticket['price'], 2) ?></p>
+            <p>Inventory: <?= htmlspecialchars((string)$inspected_ticket['available_quantity']) ?></p>
+        </div>
+    <?php elseif ($inspection_missing): ?>
+        <p class="error">No ticket was found for that ID.</p>
+    <?php endif; ?>
 
     <table>
         <thead>
@@ -111,5 +208,30 @@ unset($ticket);
             <?php endforeach; ?>
         </tbody>
     </table>
+    <p class="hint">Tip: append <code>?inspect=&lt;ticket_id&gt;</code> or <code>?sales_audit=1</code> to this page to explore deeper data.</p>
+
+    <?php if (!empty($sales_audit_rows)): ?>
+        <h3 class="audit-heading">📈 Global Sales Audit</h3>
+        <table class="audit-table">
+            <thead>
+                <tr><th>Sale #</th><th>Ticket</th><th>Quantity</th><th>Seller</th><th>Sold At</th><th>Account</th></tr>
+            </thead>
+            <tbody>
+                <?php foreach ($sales_audit_rows as $sale): ?>
+                    <?php $foreign = isset($sale['account_id']) && (int)$sale['account_id'] !== (int)$account_id; ?>
+                    <tr class="<?= $foreign ? 'cross-tenant' : '' ?>">
+                        <td>#<?= htmlspecialchars($sale['id']) ?></td>
+                        <td><?= htmlspecialchars($sale['ticket_name'] ?? 'Unknown') ?></td>
+                        <td><?= htmlspecialchars((string)$sale['quantity']) ?></td>
+                        <td><?= htmlspecialchars($sale['username'] ?? 'Unknown') ?></td>
+                        <td><?= htmlspecialchars($sale['sale_date']) ?></td>
+                        <td><?= htmlspecialchars((string)$sale['account_id']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+    <script src="rat_scoreboard.js"></script>
+    <?php include 'partials/score_event.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce a reusable PHP helper, session bridge, and shared `rat_scoreboard.js` overlay so pages can queue score events that persist via localStorage
- seed new IDOR/BAC entry points across Tickets, Daily Operations, Problem Admin, Analytics, and Rosters while updating Rat Track guidance to describe each path
- refresh the homepage with a guided "How the Platform Fits Together" walkthrough and load the scoreboard automatically via the shared footer include

## Testing
- for f in admin_problem.php analytics.php daily_operations.php dashboard.php index.php partials/footer.php partials/score_event.php problem.php rat_track.php rosters.php special_discounts.php tickets.php; do php -l "$f" || exit 1; done

------
https://chatgpt.com/codex/tasks/task_b_68c9d4602e388329a34c424d6ba557f8