### PR TITLE
Add themed landing page and temporary tenant generator

### DIFF
--- a/generate_tenant.php
+++ b/generate_tenant.php
@@ -1,0 +1,289 @@
+<?php
+require 'vendor/autoload.php';
+require 'db.php';
+require_once 'temporary_tenants.php';
+
+session_start();
+
+ensureTemporaryTenantSchema($pdo);
+cleanupExpiredTemporaryTenants($pdo);
+
+$sessionId = session_id();
+$activeTenant = getActiveTemporaryTenant($pdo, $sessionId);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $activeTenant === null) {
+    $activeTenant = createTemporaryTenant($pdo, $sessionId);
+}
+
+if ($activeTenant === null) {
+    header('Location: index.php');
+    exit;
+}
+
+$_SESSION['temporary_tenant_id'] = $activeTenant['id'];
+
+$expiresAtUtc = new DateTime($activeTenant['expires_at'], new DateTimeZone('UTC'));
+$localTz = new DateTimeZone(date_default_timezone_get());
+$expiresAtLocal = clone $expiresAtUtc;
+$expiresAtLocal->setTimezone($localTz);
+$expiresAtDisplay = $expiresAtLocal->format('M j, Y g:i A T');
+$nowLocal = new DateTime('now', $localTz);
+$timeRemaining = '';
+if ($expiresAtLocal > $nowLocal) {
+    $diff = $nowLocal->diff($expiresAtLocal);
+    $totalHours = ($diff->days * 24) + $diff->h;
+    if ($totalHours > 0) {
+        $timeRemaining = $totalHours . ' hour' . ($totalHours === 1 ? '' : 's');
+        if ($diff->i > 0) {
+            $timeRemaining .= ' ' . $diff->i . ' minute' . ($diff->i === 1 ? '' : 's');
+        }
+    } else {
+        $timeRemaining = $diff->i . ' minute' . ($diff->i === 1 ? '' : 's');
+    }
+}
+
+$credentialRows = [
+    [
+        'role' => 'Admin Ringmaster',
+        'username' => $activeTenant['admin_username'],
+        'password' => $activeTenant['admin_password'],
+        'mission' => 'Configure settings, invite staff, and explore every dashboard to understand how the park runs end-to-end.',
+    ],
+    [
+        'role' => 'Operations Manager',
+        'username' => $activeTenant['manager_username'],
+        'password' => $activeTenant['manager_password'],
+        'mission' => 'Build rosters, review incident queues, and make sure each attraction is fully staffed.',
+    ],
+    [
+        'role' => 'Ticket Seller',
+        'username' => $activeTenant['seller_username'],
+        'password' => $activeTenant['seller_password'],
+        'mission' => 'Sell tickets, manage discounts, and keep an eye on sales analytics.',
+    ],
+    [
+        'role' => 'Ride Operator',
+        'username' => $activeTenant['operator_username'],
+        'password' => $activeTenant['operator_password'],
+        'mission' => 'Check personal rosters, report ride hiccups, and collaborate with maintenance.',
+    ],
+];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Your RatPack Park Playground</title>
+    <style>
+        :root {
+            --park-purple: #5d2ca8;
+            --park-magenta: #ff5fa2;
+            --park-gold: #ffcc29;
+            --park-teal: #27d8d5;
+            --park-navy: #1b1155;
+            --park-cream: #fff7ea;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+            color: var(--park-navy);
+            background: radial-gradient(circle at top, rgba(255, 245, 230, 0.85), rgba(241, 223, 255, 0.95)),
+                linear-gradient(135deg, #1a2a6c 0%, #fdbb2d 100%);
+            min-height: 100vh;
+            padding: 70px 20px 120px;
+        }
+        .wrap {
+            max-width: 960px;
+            margin: 0 auto;
+            background: rgba(255, 247, 234, 0.95);
+            border-radius: 30px;
+            padding: 56px 60px;
+            box-shadow: 0 40px 90px rgba(27, 17, 85, 0.15);
+            position: relative;
+            overflow: hidden;
+        }
+        .wrap::before,
+        .wrap::after {
+            content: '';
+            position: absolute;
+            border-radius: 50%;
+            opacity: 0.25;
+        }
+        .wrap::before {
+            width: 320px;
+            height: 320px;
+            background: var(--park-magenta);
+            top: -140px;
+            right: -120px;
+            filter: blur(1px);
+        }
+        .wrap::after {
+            width: 220px;
+            height: 220px;
+            background: var(--park-teal);
+            bottom: -120px;
+            left: -90px;
+            filter: blur(1px);
+        }
+        h1 {
+            font-size: clamp(2.2rem, 4vw, 3rem);
+            margin: 0 0 12px;
+        }
+        .subtitle {
+            font-size: 1.05rem;
+            color: rgba(27, 17, 85, 0.7);
+            margin-bottom: 32px;
+        }
+        .highlight-box {
+            background: rgba(39, 216, 213, 0.12);
+            border: 1px solid rgba(39, 216, 213, 0.4);
+            border-radius: 18px;
+            padding: 22px 26px;
+            margin-bottom: 36px;
+        }
+        .highlight-box strong {
+            color: var(--park-purple);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 40px;
+            position: relative;
+            z-index: 1;
+        }
+        thead {
+            background: linear-gradient(135deg, rgba(93, 44, 168, 0.85), rgba(255, 95, 162, 0.85));
+            color: white;
+        }
+        th, td {
+            padding: 16px 18px;
+            text-align: left;
+        }
+        tbody tr:nth-child(even) {
+            background: rgba(255, 247, 234, 0.65);
+        }
+        tbody tr:nth-child(odd) {
+            background: rgba(255, 255, 255, 0.8);
+        }
+        code {
+            font-family: 'Fira Code', 'Courier New', monospace;
+            font-size: 0.95rem;
+            background: rgba(27, 17, 85, 0.08);
+            padding: 2px 6px;
+            border-radius: 6px;
+        }
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            margin-top: 12px;
+        }
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 12px 22px;
+            border-radius: 999px;
+            font-weight: 600;
+            text-decoration: none;
+            border: 2px solid transparent;
+            background: linear-gradient(135deg, var(--park-purple), var(--park-magenta));
+            color: white;
+            box-shadow: 0 16px 32px rgba(93, 44, 168, 0.22);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 40px rgba(93, 44, 168, 0.28);
+        }
+        .notes {
+            margin-top: 40px;
+            line-height: 1.8;
+            color: rgba(27, 17, 85, 0.75);
+            position: relative;
+            z-index: 1;
+        }
+        .notes h2 {
+            margin-top: 0;
+        }
+        ul.checklist {
+            list-style: none;
+            padding: 0;
+            margin: 16px 0 0;
+        }
+        ul.checklist li {
+            padding-left: 28px;
+            position: relative;
+            margin-bottom: 12px;
+        }
+        ul.checklist li::before {
+            content: '✔';
+            position: absolute;
+            left: 0;
+            color: var(--park-teal);
+            font-weight: 700;
+        }
+        @media (max-width: 768px) {
+            body {
+                padding: 32px 12px 80px;
+            }
+            .wrap {
+                padding: 42px 24px;
+            }
+            th, td {
+                padding: 12px 14px;
+                font-size: 0.95rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="wrap">
+        <h1>🎡 Temporary Tenant Ready!</h1>
+        <p class="subtitle">Share these credentials with your testers and explore every inch of RatPack Park's control center.</p>
+        <div class="highlight-box">
+            <p><strong>Tenant name:</strong> <?php echo htmlspecialchars($activeTenant['account_name']); ?> (Account ID #<?php echo htmlspecialchars((string)$activeTenant['account_id']); ?>)</p>
+            <p><strong>Expires:</strong> <?php echo htmlspecialchars($expiresAtDisplay); ?><?php echo $timeRemaining ? ' — about ' . htmlspecialchars($timeRemaining) . ' remaining' : ''; ?></p>
+            <p>When the clock strikes zero, we automatically retire this tenant and all related data. No cleanup required.</p>
+        </div>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Persona</th>
+                    <th>Username</th>
+                    <th>Password</th>
+                    <th>Mission Brief</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($credentialRows as $row): ?>
+                    <tr>
+                        <td><?php echo htmlspecialchars($row['role']); ?></td>
+                        <td><code><?php echo htmlspecialchars($row['username']); ?></code></td>
+                        <td><code><?php echo htmlspecialchars($row['password']); ?></code></td>
+                        <td><?php echo htmlspecialchars($row['mission']); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+
+        <div class="notes">
+            <h2>Next Steps</h2>
+            <ul class="checklist">
+                <li>Visit <code><?php echo htmlspecialchars((string)($_SERVER['HTTP_HOST'] ?? 'your-lab-host')); ?>/login.php</code> and sign in as the Admin Ringmaster first.</li>
+                <li>Invite additional teammates or rotate through each persona using the credentials above.</li>
+                <li>Experiment with rosters, ticket types, maintenance logs, and analytics dashboards to experience the full park lifecycle.</li>
+                <li>Need another sandbox after this one? Return to the home page once the 12-hour timer expires and generate a fresh tenant.</li>
+            </ul>
+        </div>
+
+        <div class="actions">
+            <a class="btn" href="index.php" target="_self">Back to RatPack Park Home</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,9 +1,41 @@
 <?php
 require 'vendor/autoload.php';
 require 'db.php';
-use Firebase\JWT\JWT;
-use Firebase\JWT\Key;
+require_once 'temporary_tenants.php';
 
+session_start();
+
+ensureTemporaryTenantSchema($pdo);
+cleanupExpiredTemporaryTenants($pdo);
+
+$sessionId = session_id();
+$activeTenant = getActiveTemporaryTenant($pdo, $sessionId);
+if ($activeTenant !== null) {
+    $_SESSION['temporary_tenant_id'] = $activeTenant['id'];
+}
+
+$expiresAtDisplay = null;
+$timeRemaining = null;
+if ($activeTenant !== null) {
+    $expiresAt = new DateTime($activeTenant['expires_at'], new DateTimeZone('UTC'));
+    $localTz = new DateTimeZone(date_default_timezone_get());
+    $expiresAt->setTimezone($localTz);
+    $expiresAtDisplay = $expiresAt->format('M j, Y g:i A T');
+
+    $nowLocal = new DateTime('now', $localTz);
+    if ($expiresAt > $nowLocal) {
+        $diff = $nowLocal->diff($expiresAt);
+        $totalHours = ($diff->days * 24) + $diff->h;
+        if ($totalHours > 0) {
+            $timeRemaining = $totalHours . ' hour' . ($totalHours === 1 ? '' : 's');
+            if ($diff->i > 0) {
+                $timeRemaining .= ' ' . $diff->i . ' minute' . ($diff->i === 1 ? '' : 's');
+            }
+        } else {
+            $timeRemaining = $diff->i . ' minute' . ($diff->i === 1 ? '' : 's');
+        }
+    }
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -11,79 +43,259 @@ use Firebase\JWT\Key;
     <meta charset="UTF-8">
     <title>RatPack Park Management</title>
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            background: linear-gradient(to bottom right, #f3e5f5, #ede7f6);
-            margin: 0;
-            padding: 0;
+        :root {
+            --park-purple: #5d2ca8;
+            --park-magenta: #ff5fa2;
+            --park-gold: #ffcc29;
+            --park-teal: #27d8d5;
+            --park-navy: #1b1155;
+            --park-cream: #fff7ea;
         }
-        .container {
-            max-width: 800px;
-            margin: 80px auto;
-            padding: 40px;
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+            color: var(--park-navy);
+            background: radial-gradient(circle at top, rgba(255, 245, 230, 0.85), rgba(241, 223, 255, 0.95)),
+                linear-gradient(135deg, #1a2a6c 0%, #fdbb2d 100%);
+            min-height: 100vh;
+        }
+        .aurora {
+            position: fixed;
+            inset: 0;
+            background: radial-gradient(circle at 20% 20%, rgba(255, 111, 162, 0.35), transparent 55%),
+                        radial-gradient(circle at 80% 15%, rgba(39, 216, 213, 0.35), transparent 50%),
+                        radial-gradient(circle at 50% 80%, rgba(255, 204, 41, 0.25), transparent 60%);
+            z-index: 0;
+            pointer-events: none;
+        }
+        .landing {
+            position: relative;
+            z-index: 1;
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 80px 24px 120px;
+        }
+        .hero {
+            background: rgba(255, 247, 234, 0.92);
+            border-radius: 28px;
+            padding: 56px 60px;
+            box-shadow: 0 30px 80px rgba(29, 17, 85, 0.15);
+            position: relative;
+            overflow: hidden;
+        }
+        .hero::before,
+        .hero::after {
+            content: '';
+            position: absolute;
+            border-radius: 50%;
+            opacity: 0.35;
+            filter: blur(0.5px);
+        }
+        .hero::before {
+            width: 260px;
+            height: 260px;
+            background: var(--park-magenta);
+            top: -120px;
+            right: -80px;
+        }
+        .hero::after {
+            width: 180px;
+            height: 180px;
+            background: var(--park-teal);
+            bottom: -80px;
+            left: -60px;
+        }
+        .hero__badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background: rgba(93, 44, 168, 0.12);
+            color: var(--park-purple);
+            padding: 8px 18px;
+            border-radius: 999px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+        }
+        h1 {
+            font-size: clamp(2.4rem, 5vw, 3.4rem);
+            margin: 20px 0 12px;
+            line-height: 1.1;
+        }
+        .hero__lead {
+            font-size: 1.1rem;
+            max-width: 640px;
+            line-height: 1.7;
+            color: rgba(27, 17, 85, 0.75);
+        }
+        .hero__actions {
+            margin: 36px 0 20px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+        }
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 14px 26px;
+            border-radius: 999px;
+            font-weight: 600;
+            text-decoration: none;
+            border: 2px solid transparent;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
+        }
+        .btn:hover:not([disabled]) {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px rgba(93, 44, 168, 0.2);
+        }
+        .btn:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+            box-shadow: none;
+        }
+        .btn-primary {
+            background: linear-gradient(135deg, var(--park-purple), var(--park-magenta));
+            color: white;
+        }
+        .btn-outline {
+            border-color: rgba(93, 44, 168, 0.35);
+            color: var(--park-purple);
             background: white;
-            border-radius: 12px;
-            box-shadow: 0 8px 20px rgba(0,0,0,0.1);
-            text-align: center;
+        }
+        .btn-outline:hover:not([disabled]) {
+            background: rgba(93, 44, 168, 0.08);
+        }
+        .btn-accent {
+            background: linear-gradient(135deg, var(--park-gold), var(--park-magenta));
+            color: var(--park-navy);
+        }
+        .tenant-form {
+            margin-top: 10px;
+        }
+        .tenant-card {
+            margin-top: 28px;
+            padding: 22px 24px;
+            border-radius: 18px;
+            background: rgba(39, 216, 213, 0.12);
+            border: 1px solid rgba(39, 216, 213, 0.35);
+        }
+        .tenant-card h3 {
+            margin-top: 0;
+            margin-bottom: 8px;
+        }
+        .tenant-hint {
+            margin-top: 16px;
+            color: rgba(27, 17, 85, 0.65);
+            font-size: 0.95rem;
+        }
+        .feature-grid {
+            margin-top: 70px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 28px;
+        }
+        .feature-card {
+            background: rgba(255, 247, 234, 0.88);
+            border-radius: 20px;
+            padding: 28px;
+            border: 1px solid rgba(93, 44, 168, 0.12);
+            box-shadow: 0 20px 40px rgba(27, 17, 85, 0.08);
+        }
+        .feature-card h3 {
+            margin-top: 0;
+            display: flex;
+            align-items: center;
+            gap: 12px;
         }
         .guide {
-            margin: 30px 0;
-            text-align: left;
-            background: #f8f3ff;
-            border-radius: 12px;
-            padding: 20px 24px;
-            box-shadow: inset 0 0 0 1px rgba(106, 27, 154, 0.12);
+            margin-top: 80px;
+            background: white;
+            padding: 40px 44px;
+            border-radius: 24px;
+            box-shadow: 0 24px 60px rgba(27, 17, 85, 0.12);
+            border: 1px solid rgba(93, 44, 168, 0.1);
         }
         .guide h2 {
-            color: #4a148c;
             margin-top: 0;
         }
         .guide ol {
-            margin: 0;
-            padding-left: 20px;
-            color: #444;
-            line-height: 1.6;
+            margin: 18px 0 0;
+            padding-left: 22px;
+            line-height: 1.8;
         }
-        h1 {
-            color: #6a1b9a;
-        }
-        p {
-            font-size: 18px;
-            color: #555;
-        }
-        a.button {
-            display: inline-block;
-            padding: 12px 24px;
-            margin: 10px;
-            background: #6a1b9a;
-            color: white;
-            text-decoration: none;
-            border-radius: 8px;
-            transition: background 0.3s ease;
-        }
-        a.button:hover {
-            background: #4a148c;
+        @media (max-width: 768px) {
+            .landing {
+                padding: 60px 16px 100px;
+            }
+            .hero {
+                padding: 46px 32px;
+            }
+            .hero__actions {
+                flex-direction: column;
+                align-items: stretch;
+            }
+            .btn {
+                width: 100%;
+            }
         }
     </style>
 </head>
 <body>
-    <div class="container">
-        <h1>🎢 Welcome to RatPack Park Management</h1>
-        <p>
-            Manage your entire theme park effortlessly. From shift rosters to ticket sales, we've got it covered.<br>
-            Try it now and see how it transforms your operations.
-        </p>
-        <div class="guide">
-            <h2>How the Platform Fits Together</h2>
+    <div class="aurora"></div>
+    <main class="landing">
+        <section class="hero">
+            <span class="hero__badge">RatPack Park Platform</span>
+            <h1>Design, staff, and thrill your park from a single control center.</h1>
+            <p class="hero__lead">Our whimsical dashboards keep your crews choreographed, your rides humming, and your guests talking about the magic long after the gates close.</p>
+            <div class="hero__actions">
+                <a class="btn btn-primary" href="register.php">Start Free Trial</a>
+                <a class="btn btn-outline" href="login.php">Already a Member? Log In</a>
+            </div>
+            <form class="tenant-form" method="POST" action="generate_tenant.php" target="_blank">
+                <button type="submit" class="btn btn-accent" <?php echo $activeTenant ? 'disabled' : ''; ?>>Generate a temporary tenant</button>
+            </form>
+            <?php if ($activeTenant): ?>
+                <div class="tenant-card">
+                    <h3>🎟️ You're already running a temporary tenant!</h3>
+                    <p>Your playground <strong><?php echo htmlspecialchars($activeTenant['account_name']); ?></strong> will pack up on <strong><?php echo htmlspecialchars($expiresAtDisplay ?? ''); ?></strong><?php echo $timeRemaining ? ' (in ~' . htmlspecialchars($timeRemaining) . ')' : ''; ?>.</p>
+                    <a class="btn btn-outline" href="generate_tenant.php" target="_blank" rel="noopener">Open your credential guide</a>
+                </div>
+            <?php else: ?>
+                <p class="tenant-hint">Need a zero-setup playground? Spin up a temporary tenant and receive four themed logins to explore every dashboard. It self-destructs after 12 hours, leaving no cleanup behind.</p>
+            <?php endif; ?>
+        </section>
+
+        <section class="feature-grid">
+            <article class="feature-card">
+                <h3>🎢 Ride-Ready Scheduling</h3>
+                <p>Coordinate attractions, vendors, and maintenance crews with colorful roster tools built for high-energy parks.</p>
+            </article>
+            <article class="feature-card">
+                <h3>💡 Live Operations Pulse</h3>
+                <p>Track ticket sales, revenue surges, and surprise downtime so you can dispatch teams before the queue gets restless.</p>
+            </article>
+            <article class="feature-card">
+                <h3>🛠️ Rapid Incident Response</h3>
+                <p>From sticky turnstiles to stargazing events, capture and triage every report with an audit trail your managers will love.</p>
+            </article>
+            <article class="feature-card">
+                <h3>🎯 Role-Based Control</h3>
+                <p>Admins, managers, sellers, and operators each get curated dashboards that make their responsibilities shine.</p>
+            </article>
+        </section>
+
+        <section class="guide">
+            <h2>Map Out Your Park Adventure</h2>
             <ol>
-                <li><strong>Create your organisation:</strong> Register a trial account to generate a brand new tenant with an administrator user.</li>
-                <li><strong>Invite and schedule your crew:</strong> Configure ticket types and discounts, create staff through User Management, and arrange their shifts within Rosters.</li>
-                <li><strong>Operate the park:</strong> Track daily metrics in Daily Operations, sell tickets, and watch revenue update automatically.</li>
-                <li><strong>Stay on top of issues:</strong> Log incidents from the Report Problem area and triage them through the Admin Problem view.</li>
-                <li><strong>Review performance:</strong> Visit Analytics for tenant-wide KPIs and Rat Track to study known weaknesses and challenges.</li>
+                <li><strong>Launch your tenant:</strong> Register or generate a temporary playground to receive admin credentials instantly.</li>
+                <li><strong>Cast your crew:</strong> Invite staff in User Management, assign roles, and place them on rosters that match ride hours.</li>
+                <li><strong>Keep the magic alive:</strong> Sell tickets, monitor daily operations, and escalate issues before guests notice.</li>
+                <li><strong>Study the thrill factor:</strong> Dive into Analytics and Rat Track to pinpoint bottlenecks and celebrate wins.</li>
             </ol>
-        </div>
-        <a class="button" href="register.php">Start Free Trial</a>
-        <a class="button" href="login.php">Already a Member? Log In</a>
-    </div>
+        </section>
+    </main>
     <?php include 'partials/footer.php'; ?>

--- a/temporary_tenants.php
+++ b/temporary_tenants.php
@@ -1,0 +1,211 @@
+<?php
+// Utility functions to manage temporary tenant lifecycle
+
+if (!function_exists('ensureTemporaryTenantSchema')) {
+    function ensureTemporaryTenantSchema(PDO $pdo): void
+    {
+        $pdo->exec(
+            "CREATE TABLE IF NOT EXISTS temporary_tenants (" .
+            "id INT AUTO_INCREMENT PRIMARY KEY," .
+            "session_id VARCHAR(255) NOT NULL," .
+            "account_id INT NOT NULL," .
+            "account_name VARCHAR(150) NOT NULL," .
+            "admin_username VARCHAR(100) NOT NULL," .
+            "admin_password VARCHAR(100) NOT NULL," .
+            "manager_username VARCHAR(100) NOT NULL," .
+            "manager_password VARCHAR(100) NOT NULL," .
+            "operator_username VARCHAR(100) NOT NULL," .
+            "operator_password VARCHAR(100) NOT NULL," .
+            "seller_username VARCHAR(100) NOT NULL," .
+            "seller_password VARCHAR(100) NOT NULL," .
+            "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP," .
+            "expires_at DATETIME NOT NULL," .
+            "destroyed_at DATETIME DEFAULT NULL," .
+            "KEY idx_session_destroyed (session_id, destroyed_at)" .
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+        );
+    }
+}
+
+if (!function_exists('cleanupExpiredTemporaryTenants')) {
+    function cleanupExpiredTemporaryTenants(PDO $pdo): void
+    {
+        ensureTemporaryTenantSchema($pdo);
+        $stmt = $pdo->prepare("SELECT * FROM temporary_tenants WHERE destroyed_at IS NULL AND expires_at <= UTC_TIMESTAMP()");
+        $stmt->execute();
+        $tenants = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($tenants as $tenant) {
+            destroyTemporaryTenant($pdo, $tenant);
+        }
+    }
+}
+
+if (!function_exists('destroyTemporaryTenant')) {
+    function destroyTemporaryTenant(PDO $pdo, array $tenant): void
+    {
+        $pdo->beginTransaction();
+        try {
+            $accountId = (int)$tenant['account_id'];
+
+            // Remove related problem notes and reports before deleting the account to respect FK constraints.
+            $problemIdsStmt = $pdo->prepare("SELECT id FROM problem_reports WHERE account_id = ?");
+            $problemIdsStmt->execute([$accountId]);
+            $problemIds = $problemIdsStmt->fetchAll(PDO::FETCH_COLUMN);
+            if (!empty($problemIds)) {
+                $placeholders = implode(',', array_fill(0, count($problemIds), '?'));
+                $notesDelete = $pdo->prepare("DELETE FROM problem_notes WHERE problem_id IN ($placeholders)");
+                $notesDelete->execute($problemIds);
+            }
+
+            $problemDelete = $pdo->prepare("DELETE FROM problem_reports WHERE account_id = ?");
+            $problemDelete->execute([$accountId]);
+
+            // Deleting the account cascades to users, tickets, shifts, etc.
+            $accountDelete = $pdo->prepare("DELETE FROM accounts WHERE id = ?");
+            $accountDelete->execute([$accountId]);
+
+            $markDestroyed = $pdo->prepare("UPDATE temporary_tenants SET destroyed_at = UTC_TIMESTAMP() WHERE id = ?");
+            $markDestroyed->execute([(int)$tenant['id']]);
+
+            $pdo->commit();
+        } catch (Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+}
+
+if (!function_exists('getActiveTemporaryTenant')) {
+    function getActiveTemporaryTenant(PDO $pdo, string $sessionId): ?array
+    {
+        ensureTemporaryTenantSchema($pdo);
+        $stmt = $pdo->prepare(
+            "SELECT * FROM temporary_tenants WHERE session_id = ? AND destroyed_at IS NULL ORDER BY created_at DESC LIMIT 1"
+        );
+        $stmt->execute([$sessionId]);
+        $tenant = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($tenant === false) {
+            return null;
+        }
+
+        $expiresAt = new DateTime($tenant['expires_at'], new DateTimeZone('UTC'));
+        $now = new DateTime('now', new DateTimeZone('UTC'));
+        if ($expiresAt <= $now) {
+            destroyTemporaryTenant($pdo, $tenant);
+            return null;
+        }
+
+        return $tenant;
+    }
+}
+
+if (!function_exists('createTemporaryTenant')) {
+    function createTemporaryTenant(PDO $pdo, string $sessionId): array
+    {
+        cleanupExpiredTemporaryTenants($pdo);
+        $existing = getActiveTemporaryTenant($pdo, $sessionId);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $pdo->beginTransaction();
+        try {
+            $accountName = 'Temp Tenant ' . strtoupper(bin2hex(random_bytes(3)));
+            $insertAccount = $pdo->prepare("INSERT INTO accounts (name, contact_email) VALUES (?, ?)");
+            $insertAccount->execute([$accountName, null]);
+            $accountId = (int)$pdo->lastInsertId();
+
+            $roles = [
+                'admin' => 1,
+                'manager' => 2,
+                'seller' => 3,
+                'operator' => 4,
+            ];
+
+            $credentialMap = [];
+            foreach ($roles as $label => $roleId) {
+                $username = buildUniqueUsername($pdo, $label);
+                $passwordPlain = generateReadablePassword();
+                $email = $username . "@example.com";
+                $passwordHash = password_hash($passwordPlain, PASSWORD_BCRYPT);
+
+                $insertUser = $pdo->prepare(
+                    "INSERT INTO users (account_id, role_id, username, email, password_hash) VALUES (?, ?, ?, ?, ?)"
+                );
+                $insertUser->execute([$accountId, $roleId, $username, $email, $passwordHash]);
+
+                $credentialMap[$label] = [
+                    'username' => $username,
+                    'password' => $passwordPlain,
+                ];
+            }
+
+            $expiresAt = new DateTime('now', new DateTimeZone('UTC'));
+            $expiresAt->modify('+12 hours');
+
+            $insertTemp = $pdo->prepare(
+                "INSERT INTO temporary_tenants (session_id, account_id, account_name, admin_username, admin_password, " .
+                "manager_username, manager_password, operator_username, operator_password, seller_username, seller_password, expires_at) " .
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            );
+            $insertTemp->execute([
+                $sessionId,
+                $accountId,
+                $accountName,
+                $credentialMap['admin']['username'],
+                $credentialMap['admin']['password'],
+                $credentialMap['manager']['username'],
+                $credentialMap['manager']['password'],
+                $credentialMap['operator']['username'],
+                $credentialMap['operator']['password'],
+                $credentialMap['seller']['username'],
+                $credentialMap['seller']['password'],
+                $expiresAt->format('Y-m-d H:i:s'),
+            ]);
+
+            $tempId = (int)$pdo->lastInsertId();
+            $pdo->commit();
+
+            $record = getActiveTemporaryTenant($pdo, $sessionId);
+            if ($record === null) {
+                throw new RuntimeException('Temporary tenant was created but could not be reloaded.');
+            }
+
+            if (session_status() === PHP_SESSION_ACTIVE) {
+                $_SESSION['temporary_tenant_id'] = $tempId;
+            }
+            return $record;
+        } catch (Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+}
+
+if (!function_exists('buildUniqueUsername')) {
+    function buildUniqueUsername(PDO $pdo, string $label): string
+    {
+        $base = 'temp_' . preg_replace('/[^a-z0-9]/', '', strtolower($label));
+        do {
+            $suffix = strtoupper(substr(bin2hex(random_bytes(4)), 0, 6));
+            $username = $base . '_' . $suffix;
+            $check = $pdo->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+            $check->execute([$username]);
+        } while ((int)$check->fetchColumn() > 0);
+
+        return $username;
+    }
+}
+
+if (!function_exists('generateReadablePassword')) {
+    function generateReadablePassword(int $length = 12): string
+    {
+        $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^*';
+        $maxIndex = strlen($alphabet) - 1;
+        $password = '';
+        for ($i = 0; $i < $length; $i++) {
+            $password .= $alphabet[random_int(0, $maxIndex)];
+        }
+        return $password;
+    }
+}

--- a/tests/selenium/README.md
+++ b/tests/selenium/README.md
@@ -1,0 +1,71 @@
+# Selenium smoke tests
+
+These end-to-end tests now include both smoke coverage and a broader regression
+suite that exercises the primary workflows for each role:
+
+* **Normal operators** sign in, review their roster, submit incident reports, and
+  confirm the Rat Track knowledge base renders.
+* **Admins** validate every sidebar destination including staffing rosters,
+  analytics, ticketing, discount management, incident management, and daily
+  operations.
+
+## Prerequisites
+
+1. A running instance of RatPack Park that you can reach from your machine. The defaults assume `http://localhost:8000`.
+2. Google Chrome (version 115 or later) installed locally.
+3. Either:
+   * `chromedriver` on your `PATH`, **or**
+   * Python package [`webdriver-manager`](https://pypi.org/project/webdriver-manager/) (installed automatically via the requirements below) and outbound network access so it can download the appropriate driver the first time it runs.
+4. Python 3.9+ and `pip`.
+
+## Setup
+
+```bash
+cd /path/to/RatPackPark
+python -m venv .venv
+source .venv/bin/activate
+pip install -r tests/selenium/requirements.txt
+```
+
+If your application is not running on `http://localhost:8000`, set the `RATPACK_BASE_URL` environment variable before running the tests:
+
+```bash
+export RATPACK_BASE_URL="http://127.0.0.1:8080"
+```
+
+If `chromedriver` is installed in a non-standard location, point the suite at it:
+
+```bash
+export CHROMEDRIVER="/usr/local/bin/chromedriver"
+```
+
+## Starting the application
+
+The tests assume the PHP application is already running. If you use the provided Docker Compose setup you can start it with:
+
+```bash
+docker compose up --build
+```
+
+Or, if you are using the built-in PHP server with a local `.env`, you can run:
+
+```bash
+php -S localhost:8000
+```
+
+Make sure the database referenced by `db.php` is reachable and seeded with `init.sql` so that the built-in accounts (`test` / `test` for admins and `low` / `low` for operators) exist.
+
+## Running the tests
+
+With the application running and the virtual environment activated, execute:
+
+```bash
+pytest tests/selenium
+```
+
+Pytest will launch a headless Chrome browser, sign in as both user roles, and
+validate that the main dashboard features load without errors. The regression
+suite (`tests/selenium/test_regression.py`) verifies that each admin page
+renders critical UI elements and that operators see the correct, restricted
+navigation set.
+

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+
+import pytest
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Base URL of the running RatPack Park instance."""
+    return os.getenv("RATPACK_BASE_URL", "http://localhost:8000")
+
+
+@pytest.fixture(scope="session")
+def chrome_service(tmp_path_factory):
+    """Return a configured Chrome Service, preferring a local chromedriver."""
+    driver_path = os.getenv("CHROMEDRIVER") or shutil.which("chromedriver")
+    if driver_path:
+        return Service(executable_path=driver_path)
+
+    try:
+        from webdriver_manager.chrome import ChromeDriverManager
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise RuntimeError(
+            "chromedriver not found on PATH and webdriver-manager not installed. "
+            "Install webdriver-manager or provide CHROMEDRIVER."
+        ) from exc
+
+    cache_dir = tmp_path_factory.mktemp("wdm")
+    executable = ChromeDriverManager(path=cache_dir).install()
+    return Service(executable_path=executable)
+
+
+@pytest.fixture
+def driver(chrome_service):
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1280,720")
+
+    with webdriver.Chrome(service=chrome_service, options=options) as driver:
+        yield driver
+

--- a/tests/selenium/helpers.py
+++ b/tests/selenium/helpers.py
@@ -1,0 +1,60 @@
+"""Shared helpers for RatPack Park Selenium tests."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+LOGIN_BUTTON = (By.CSS_SELECTOR, "button[type='submit']")
+SIDEBAR = (By.CLASS_NAME, "sidebar")
+MAIN_IFRAME = (By.CSS_SELECTOR, "iframe[name='mainframe']")
+
+
+class Dashboard:
+    """Helper around the RatPack Park dashboard layout."""
+
+    def __init__(self, driver: WebDriver) -> None:
+        self.driver = driver
+
+    def wait_until_loaded(self) -> None:
+        WebDriverWait(self.driver, 10).until(EC.presence_of_element_located(SIDEBAR))
+
+    def open_menu_item(self, link_text: str) -> WebDriver:
+        """Click a sidebar link and switch into the main iframe."""
+        self.driver.switch_to.default_content()
+        WebDriverWait(self.driver, 10).until(EC.element_to_be_clickable((By.LINK_TEXT, link_text))).click()
+        WebDriverWait(self.driver, 10).until(EC.frame_to_be_available_and_switch_to_it(MAIN_IFRAME))
+        WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+        return self.driver
+
+    def exit_iframe(self) -> None:
+        self.driver.switch_to.default_content()
+
+    def visible_menu_items(self) -> Sequence[str]:
+        self.driver.switch_to.default_content()
+        elements = self.driver.find_elements(By.CSS_SELECTOR, ".sidebar a")
+        return [el.text.strip() for el in elements]
+
+
+def login(driver: WebDriver, base_url: str, username: str, password: str) -> Dashboard:
+    driver.get(f"{base_url}/login.php")
+    driver.find_element(By.NAME, "username").send_keys(username)
+    driver.find_element(By.NAME, "password").send_keys(password)
+    driver.find_element(*LOGIN_BUTTON).click()
+
+    dashboard = Dashboard(driver)
+    dashboard.wait_until_loaded()
+    return dashboard
+
+
+def assert_links_present(actual: Sequence[str], expected: Iterable[str]) -> None:
+    missing = [label for label in expected if label not in actual]
+    assert not missing, f"Missing expected menu links: {missing}"
+
+
+def assert_links_absent(actual: Sequence[str], forbidden: Iterable[str]) -> None:
+    present = [label for label in forbidden if label in actual]
+    assert not present, f"Menu unexpectedly contained: {present}"

--- a/tests/selenium/requirements.txt
+++ b/tests/selenium/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=7.0
+selenium>=4.20
+webdriver-manager>=4.0

--- a/tests/selenium/test_regression.py
+++ b/tests/selenium/test_regression.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from .helpers import (
+    assert_links_absent,
+    assert_links_present,
+    login,
+)
+
+
+OPERATOR_EXPECTED_MENU = [
+    "My Roster",
+    "Report a problem",
+    "Rat Track",
+    "Logout",
+]
+
+OPERATOR_FORBIDDEN_MENU = [
+    "Settings",
+    "Rosters",
+    "Tickets",
+    "Assign Roles",
+    "Admin problem overview",
+]
+
+ADMIN_EXPECTED_MENU = [
+    "Settings",
+    "Rosters",
+    "Tickets",
+    "Special Discounts",
+    "My Roster",
+    "Analytics",
+    "Maintenance",
+    "Report a problem",
+    "Admin problem overview",
+    "Role Management",
+    "Assign Roles",
+    "Daily Operations",
+    "Rat Track",
+    "Logout",
+]
+
+
+def wait_for_heading(driver, locator, expected_text: str) -> None:
+    heading = WebDriverWait(driver, 10).until(EC.presence_of_element_located(locator))
+    assert expected_text in heading.text
+
+
+def test_operator_navigation(driver, base_url):
+    dashboard = login(driver, base_url, "low", "low")
+    menu = dashboard.visible_menu_items()
+    assert_links_present(menu, OPERATOR_EXPECTED_MENU)
+    assert_links_absent(menu, OPERATOR_FORBIDDEN_MENU)
+
+    dashboard.open_menu_item("My Roster")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "My Roster")
+    rows = driver.find_elements(By.CSS_SELECTOR, "table tbody tr")
+    assert rows, "Expected roster rows for operator"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Report a problem")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Report a Problem")
+    assert driver.find_element(By.ID, "category")
+    assert driver.find_element(By.ID, "description")
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Rat Track")
+    wait_for_heading(driver, (By.TAG_NAME, "h1"), "Rat Track")
+    vuln_rows = driver.find_elements(By.CSS_SELECTOR, "table tbody tr")
+    assert vuln_rows, "Expected Rat Track to list vulnerabilities"
+    dashboard.exit_iframe()
+
+
+def test_admin_regression_suite(driver, base_url):
+    dashboard = login(driver, base_url, "test", "test")
+    menu = dashboard.visible_menu_items()
+
+    counts = Counter(menu)
+    duplicates = [label for label, count in counts.items() if count > 1]
+    assert not duplicates, f"Duplicate menu entries detected: {duplicates}"
+
+    assert_links_present(menu, ADMIN_EXPECTED_MENU)
+
+    dashboard.open_menu_item("Settings")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Settings")
+    options = {el.text.strip() for el in driver.find_elements(By.CSS_SELECTOR, ".settings-option")}
+    assert {"👥 User Management", "🎟️ Ticket Types"}.issubset(options)
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Rosters")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Staff Rosters")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Rosters table should list shifts"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Tickets")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Available Tickets")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Tickets should be listed"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Special Discounts")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Special Discounts")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Discounts table should render"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("My Roster")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "My Roster")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Admin roster should show shifts"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Analytics")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Analytics Dashboard")
+    cards = driver.find_elements(By.CSS_SELECTOR, ".card p")
+    assert cards and all(card.text.strip() for card in cards), "Analytics cards should have metrics"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Maintenance")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Maintenance Tasks")
+    assert driver.find_elements(By.CSS_SELECTOR, "ul li"), "Maintenance list should not be empty"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Report a problem")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Report a Problem")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Problem history should be visible"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Admin problem overview")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Admin Problem Management")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Admin problem list should render"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Role Management")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Role Management")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Role table should display entries"
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Assign Roles")
+    wait_for_heading(driver, (By.TAG_NAME, "h2"), "Assign Roles")
+    assert driver.find_elements(By.CSS_SELECTOR, "select[name='user_id'] option[value]")
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Daily Operations")
+    wait_for_heading(driver, (By.CSS_SELECTOR, ".summary-card h2"), "Daily Operations")
+    assert driver.find_elements(By.CSS_SELECTOR, ".summary-card ul.metrics li")
+    dashboard.exit_iframe()
+
+    dashboard.open_menu_item("Rat Track")
+    wait_for_heading(driver, (By.TAG_NAME, "h1"), "Rat Track")
+    assert driver.find_elements(By.CSS_SELECTOR, "table tbody tr"), "Rat Track should list guidance"
+    dashboard.exit_iframe()

--- a/tests/selenium/test_smoke.py
+++ b/tests/selenium/test_smoke.py
@@ -1,0 +1,40 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from .helpers import Dashboard, login
+
+
+def assert_table_has_rows(driver: Dashboard) -> None:
+    rows = driver.driver.find_elements(By.CSS_SELECTOR, "table tbody tr")
+    assert rows, "Expected at least one row in the table"
+
+
+def test_normal_user_can_view_my_roster(driver, base_url):
+    """Normal operator should be able to sign in and read their roster."""
+    dashboard = login(driver, base_url, "low", "low")
+    dashboard.open_menu_item("My Roster")
+
+    header = WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.XPATH, "//h2[contains(., 'My Roster')]")
+    )
+    assert "My Roster" in header.text
+
+    assert_table_has_rows(dashboard)
+    dashboard.exit_iframe()
+
+
+def test_admin_can_access_assign_roles(driver, base_url):
+    """Admin should be able to open the Assign Roles screen and see known users."""
+    dashboard = login(driver, base_url, "test", "test")
+    dashboard.open_menu_item("Assign Roles")
+
+    heading = WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.TAG_NAME, "h2"))
+    )
+    assert "Assign Roles" in heading.text
+
+    page_text = driver.find_element(By.TAG_NAME, "body").text
+    assert "low" in page_text, "Expected to find the operator user listed"
+
+    dashboard.exit_iframe()


### PR DESCRIPTION
## Summary
- restyle the public landing page with a park-themed hero, feature highlights, and temporary tenant status messaging
- add a guarded "Generate a temporary tenant" flow that provisions sample users, records expiration, and blocks duplicate requests
- provide a credential guide page and shared helper utilities to auto-expire and clean up temporary tenants after 12 hours

## Testing
- php -l index.php
- php -l generate_tenant.php
- php -l temporary_tenants.php

------
https://chatgpt.com/codex/tasks/task_b_68cbfa30c43c83299aadb6f3e6d91ff4