### PR TITLE
Restyle modules with unified park OS shell

### DIFF
--- a/admin_problem.php
+++ b/admin_problem.php
@@ -64,88 +64,96 @@ if (isset($_GET['notes'])) {
     }
 }
 ?>
+$pageTitle = 'Incident Command • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Operations response</span>
+            <h1 class="hero-title">Triage issues and steer the cleanup</h1>
+            <p class="hero-lead">
+                Review every report filed by crews, pivot into maintenance notes, and update statuses as remediation moves forward.
+            </p>
+        </div>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Admin Problem Panel | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        .container { background: white; padding: 20px; border-radius: 10px; max-width: 900px; margin: auto; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        h2 { color: #6a1b9a; text-align: center; }
-        .message { color: green; text-align: center; }
-        .error { color: #d32f2f; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.05); margin-top: 20px; }
-        th, td { padding: 10px; border-bottom: 1px solid #ccc; text-align: left; vertical-align: top; }
-        th { background: #6a1b9a; color: white; }
-        form.inline-form { display: flex; gap: 6px; align-items: center; }
-        select, button { padding: 6px; border-radius: 4px; border: 1px solid #999; }
-        .notes-card { margin-top: 20px; background: #e8eaf6; padding: 18px; border-radius: 12px; }
-        .notes-card h3 { margin-top: 0; color: #303f9f; }
-        .notes-card ul { list-style: disc; padding-left: 20px; color: #1a237e; }
-        .notes-card li { margin: 6px 0; }
-        .notes-empty { color: #555; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h2>📊 Admin Problem Management</h2>
-        <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
+        <?php if (!empty($success)): ?>
+            <div class="module-alert module-alert--success"><?php echo htmlspecialchars($success); ?></div>
+        <?php endif; ?>
+
         <?php if ($notes_problem_meta): ?>
-            <div class="notes-card">
-                <h3>🗒️ Notes for Incident #<?= htmlspecialchars($notes_problem_meta['id']) ?> (Tenant <?= htmlspecialchars((string)$notes_problem_meta['account_id']); ?>)</h3>
-                <p><strong>Category:</strong> <?= htmlspecialchars($notes_problem_meta['category']); ?> | <strong>Status:</strong> <?= htmlspecialchars($notes_problem_meta['status']); ?></p>
-                <ul>
+            <div class="module-card">
+                <h2 class="module-card__title">Maintenance notebook</h2>
+                <p class="module-card__subtitle">Incident #<?php echo htmlspecialchars($notes_problem_meta['id']); ?> · Tenant #<?php echo htmlspecialchars((string) $notes_problem_meta['account_id']); ?></p>
+                <div class="module-meta">
+                    <span>Category: <strong><?php echo htmlspecialchars($notes_problem_meta['category']); ?></strong></span>
+                    <span>Status: <strong><?php echo htmlspecialchars($notes_problem_meta['status']); ?></strong></span>
+                </div>
+                <ul class="module-list">
                     <?php if (!empty($notes_for_problem)): ?>
                         <?php foreach ($notes_for_problem as $note): ?>
-                            <li><strong><?= htmlspecialchars($note['username'] ?? 'Unknown') ?>:</strong> <?= htmlspecialchars($note['note']); ?> <em>(<?= htmlspecialchars($note['created_at']); ?>)</em></li>
+                            <li class="module-list__item">
+                                <strong><?php echo htmlspecialchars($note['username'] ?? 'Unknown'); ?>:</strong>
+                                <?php echo htmlspecialchars($note['note']); ?>
+                                <em> · <?php echo htmlspecialchars($note['created_at']); ?></em>
+                            </li>
                         <?php endforeach; ?>
                     <?php else: ?>
-                        <li class="notes-empty">No notes recorded for this problem.</li>
+                        <li class="module-list__item">No notes recorded for this incident yet.</li>
                     <?php endif; ?>
                 </ul>
             </div>
         <?php elseif ($notes_missing): ?>
-            <p class="error">No problem record exists for that ID.</p>
+            <div class="module-alert module-alert--error">No problem record exists for that ID.</div>
         <?php endif; ?>
-        <table>
-            <thead>
-                <tr>
-                    <th>Submitted By</th>
-                    <th>Category</th>
-                    <th>Description</th>
-                    <th>Status</th>
-                    <th>Submitted At</th>
-                    <th>Update</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($reports as $report): ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Problem queue</h2>
+            <p class="module-card__subtitle">Advance cases, peek at foreign tenants, and keep the park spotless.</p>
+            <table class="module-table">
+                <thead>
                     <tr>
-                        <td><?= htmlspecialchars($report['username']) ?></td>
-                        <td><?= htmlspecialchars($report['category']) ?></td>
-                        <td><?= htmlspecialchars($report['description']) ?></td>
-                        <td><?= htmlspecialchars($report['status']) ?></td>
-                        <td><?= htmlspecialchars($report['submitted_at']) ?></td>
-                        <td>
-                            <form method="POST" class="inline-form">
-                                <input type="hidden" name="report_id" value="<?= $report['id'] ?>">
-                                <select name="new_status">
-                                    <option value="open" <?= $report['status'] == 'open' ? 'selected' : '' ?>>Open</option>
-                                    <option value="in_progress" <?= $report['status'] == 'in_progress' ? 'selected' : '' ?>>In Progress</option>
-                                    <option value="resolved" <?= $report['status'] == 'resolved' ? 'selected' : '' ?>>Resolved</option>
-                                    <option value="wont_resolve" <?= $report['status'] == 'wont_resolve' ? 'selected' : '' ?>>Won't Resolve</option>
-                                </select>
-                                <button type="submit">Update</button>
-                            </form>
-                        </td>
+                        <th>Submitted by</th>
+                        <th>Category</th>
+                        <th>Description</th>
+                        <th>Status</th>
+                        <th>Submitted</th>
+                        <th>Update</th>
                     </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    <?php if (empty($reports)): ?>
+                        <tr>
+                            <td colspan="6">No incidents logged. Encourage teams to report issues from the field.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($reports as $report): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($report['username']); ?></td>
+                                <td><?php echo htmlspecialchars($report['category']); ?></td>
+                                <td><?php echo htmlspecialchars($report['description']); ?></td>
+                                <td><?php echo htmlspecialchars($report['status']); ?></td>
+                                <td><?php echo htmlspecialchars($report['submitted_at']); ?></td>
+                                <td>
+                                    <form method="POST" class="module-form module-form--inline">
+                                        <input type="hidden" name="report_id" value="<?php echo $report['id']; ?>">
+                                        <select class="input-field" name="new_status">
+                                            <option value="open" <?php echo $report['status'] == 'open' ? 'selected' : ''; ?>>Open</option>
+                                            <option value="in_progress" <?php echo $report['status'] == 'in_progress' ? 'selected' : ''; ?>>In Progress</option>
+                                            <option value="resolved" <?php echo $report['status'] == 'resolved' ? 'selected' : ''; ?>>Resolved</option>
+                                            <option value="wont_resolve" <?php echo $report['status'] == 'wont_resolve' ? 'selected' : ''; ?>>Won't Resolve</option>
+                                        </select>
+                                        <button class="btn btn-outline" type="submit">Update</button>
+                                        <a class="module-link" href="?notes=<?php echo $report['id']; ?>">Notes</a>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/analytics.php
+++ b/analytics.php
@@ -52,49 +52,48 @@ $total_users = $stmt->fetchColumn();
 $stmt = $pdo->prepare("SELECT COUNT(*) FROM tickets WHERE account_id = ?");
 $stmt->execute([$effectiveAccountId]);
 $total_tickets = $stmt->fetchColumn();
-?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Analytics | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        h2 { text-align: center; color: #6a1b9a; }
-        .card {
-            background: white;
-            padding: 20px;
-            border-radius: 12px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-            margin: 10px 0;
-            max-width: 400px;
-            margin-left: auto;
-            margin-right: auto;
-        }
-        .card h3 { color: #4a148c; margin: 0 0 10px; }
-        .card p { font-size: 20px; margin: 0; color: #333; }
-        .scope-note { text-align: center; color: #444; margin-bottom: 18px; font-size: 14px; }
-        .scope-note span { color: #6a1b9a; font-weight: 600; }
-    </style>
-</head>
-<body>
-    <h2>📊 Analytics Dashboard</h2>
-    <div class="scope-note">
-        Viewing tenant scope <span>#<?= htmlspecialchars((string)$effectiveAccountId); ?></span>
-        <?php if ($effectiveAccountId !== $account_id): ?>
-            <em>(override active)</em>
+$pageTitle = 'Analytics • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Insights &amp; metrics</span>
+            <h1 class="hero-title">Spot trends across your park portfolio</h1>
+            <p class="hero-lead">
+                Audit guest demand and staffing footprint in a single glance. Pivot the scope to peek at other tenants and uncover
+                where the biggest crowds are gathering.
+            </p>
+            <div class="module-meta">
+                <span>Default tenant ID <strong>#<?php echo htmlspecialchars((string) $account_id); ?></strong></span>
+                <span>Viewing scope <strong>#<?php echo htmlspecialchars((string) $effectiveAccountId); ?></strong></span>
+            </div>
+        </div>
+
+        <?php if ($effectiveAccountId !== (int) $account_id): ?>
+            <div class="module-alert module-alert--note">
+                Analytics override active. Provide <code>?account=<?php echo htmlspecialchars((string) $account_id); ?></code> to
+                snap back to your own tenant.
+            </div>
         <?php endif; ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Key counts</h2>
+            <p class="module-card__subtitle">Live totals computed directly from operational data across the selected tenant scope.
+            </p>
+            <div class="module-grid">
+                <div class="module-figure">
+                    <span class="module-figure__label">Total users</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars(number_format((int) $total_users)); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Total tickets</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars(number_format((int) $total_tickets)); ?></span>
+                </div>
+            </div>
+        </div>
     </div>
-    <div class="card">
-        <h3>Total Users</h3>
-        <p><?= $total_users ?></p>
-    </div>
-    <div class="card">
-        <h3>Total tickets</h3>
-        <p><?= $total_tickets ?></p>
-    </div>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -304,6 +304,364 @@ body {
     font-size: 0.95rem;
 }
 
+.section--settings {
+    padding-top: 80px;
+}
+
+.settings-shell {
+    display: grid;
+    gap: 48px;
+}
+
+.settings-header {
+    position: relative;
+    overflow: hidden;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
+}
+
+.settings-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 22px;
+    padding: 28px;
+    border: 1px solid var(--border-soft);
+    box-shadow: 0 18px 45px rgba(27, 17, 85, 0.08);
+    color: inherit;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.settings-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(93, 44, 168, 0.28);
+    box-shadow: 0 22px 55px rgba(27, 17, 85, 0.14);
+}
+
+.settings-card__icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8rem;
+    background: linear-gradient(135deg, var(--park-purple), var(--park-magenta));
+    color: white;
+    box-shadow: 0 12px 24px rgba(93, 44, 168, 0.28);
+}
+
+.settings-card__title {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.settings-card__copy {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.settings-card__cta {
+    margin-top: auto;
+    font-weight: 600;
+    color: var(--park-purple);
+}
+
+
+.section--module {
+    padding-top: 80px;
+}
+
+.module-shell {
+    display: grid;
+    gap: 48px;
+}
+
+.module-layout {
+    display: grid;
+    grid-template-columns: minmax(220px, 260px) 1fr;
+    gap: 28px;
+    align-items: flex-start;
+}
+
+.module-menu {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 22px;
+    padding: 26px 24px;
+    border: 1px solid var(--border-soft);
+    box-shadow: 0 16px 40px rgba(27, 17, 85, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.module-menu__title {
+    margin: 0 0 12px;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.module-menu__note {
+    margin-top: 12px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.module-menu__link {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 16px;
+    background: rgba(93, 44, 168, 0.08);
+    color: var(--park-purple);
+    text-decoration: none;
+    font-weight: 600;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.module-menu__link span {
+    font-size: 1.1rem;
+}
+
+.module-menu__link:hover {
+    background: rgba(93, 44, 168, 0.16);
+    transform: translateX(4px);
+}
+
+.module-stage {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 26px;
+    border: 1px solid var(--border-soft);
+    box-shadow: 0 22px 55px rgba(27, 17, 85, 0.12);
+    overflow: hidden;
+    min-height: 560px;
+    display: flex;
+    flex-direction: column;
+}
+
+.module-stage__frame {
+    flex: 1;
+    width: 100%;
+    border: none;
+    background: white;
+}
+
+.module-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 24px;
+    padding: clamp(26px, 5vw, 36px);
+    border: 1px solid var(--border-soft);
+    box-shadow: 0 18px 45px rgba(27, 17, 85, 0.1);
+}
+
+.module-card + .module-card {
+    margin-top: 24px;
+}
+
+.module-card__title {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.module-card__subtitle {
+    margin: 6px 0 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.module-meta {
+    margin-top: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.module-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-top: 28px;
+}
+
+.module-alert {
+    padding: 14px 18px;
+    border-radius: 16px;
+    font-weight: 500;
+    border: 1px solid transparent;
+}
+
+.module-alert + .module-alert {
+    margin-top: 12px;
+}
+
+.module-alert--success {
+    background: rgba(39, 216, 213, 0.14);
+    color: #0f6b6a;
+    border-color: rgba(39, 216, 213, 0.28);
+}
+
+.module-alert--error {
+    background: rgba(255, 95, 162, 0.14);
+    color: #a11850;
+    border-color: rgba(255, 95, 162, 0.32);
+}
+
+.module-alert--note {
+    background: rgba(255, 204, 41, 0.18);
+    color: #7b4b00;
+    border-color: rgba(255, 204, 41, 0.32);
+}
+
+.module-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 24px;
+}
+
+.module-table thead {
+    background: rgba(93, 44, 168, 0.12);
+    color: var(--park-navy);
+}
+
+.module-table th {
+    padding: 14px 16px;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.module-table td {
+    padding: 14px 16px;
+    border-bottom: 1px solid rgba(93, 44, 168, 0.12);
+    font-size: 0.95rem;
+    vertical-align: top;
+}
+
+.module-table tbody tr:hover {
+    background: rgba(93, 44, 168, 0.06);
+}
+
+.module-table tr.is-foreign {
+    background: rgba(255, 95, 162, 0.12);
+}
+
+.module-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 20px;
+}
+
+.module-form--inline {
+    margin: 0;
+    gap: 12px;
+}
+
+.module-form--inline .input-field {
+    margin-bottom: 0;
+    flex: 0 1 150px;
+    min-width: 120px;
+}
+
+.module-form--inline .input-field[type="time"],
+.module-form--inline .input-field[type="number"] {
+    flex: 0 1 110px;
+}
+
+.module-form--inline .btn {
+    margin-bottom: 0;
+}
+
+.module-form--inline .module-link {
+    margin-left: auto;
+}
+
+.module-link {
+    color: var(--park-purple);
+    font-weight: 600;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.module-link:hover {
+    text-decoration: underline;
+}
+
+.module-list {
+    list-style: none;
+    padding: 0;
+    margin: 24px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.module-list__item {
+    padding: 16px 18px;
+    border-radius: 16px;
+    background: rgba(93, 44, 168, 0.08);
+    color: var(--park-navy);
+    line-height: 1.5;
+}
+
+.module-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(93, 44, 168, 0.12);
+    color: var(--park-purple);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.module-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin-top: 24px;
+}
+
+.module-figure {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 16px 18px;
+    border-radius: 18px;
+    background: rgba(93, 44, 168, 0.1);
+    color: var(--park-navy);
+}
+
+.module-figure__label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+
+.module-figure__value {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
 .form-section {
     width: 100%;
     padding: 80px 24px 100px;
@@ -333,7 +691,9 @@ body {
     line-height: 1.6;
 }
 
-.input-field {
+.input-field,
+select.input-field,
+textarea.input-field {
     width: 100%;
     padding: 14px 16px;
     margin-bottom: 16px;
@@ -341,9 +701,26 @@ body {
     border-radius: 14px;
     font-size: 1rem;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: white;
+    color: inherit;
 }
 
-.input-field:focus {
+select.input-field {
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%235D2CA8' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 18px center;
+    padding-right: 46px;
+}
+
+textarea.input-field {
+    min-height: 140px;
+    resize: vertical;
+}
+
+.input-field:focus,
+select.input-field:focus,
+textarea.input-field:focus {
     outline: none;
     border-color: var(--park-purple);
     box-shadow: 0 0 0 4px rgba(93, 44, 168, 0.12);
@@ -387,6 +764,20 @@ body {
     text-decoration: underline;
 }
 
+@media (max-width: 1100px) {
+    .module-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .module-menu {
+        position: relative;
+    }
+
+    .module-stage {
+        min-height: 520px;
+    }
+}
+
 @media (max-width: 768px) {
     .top-nav {
         flex-direction: column;
@@ -400,5 +791,39 @@ body {
 
     .form-card {
         padding: 32px 28px 38px;
+    }
+
+    .settings-shell {
+        gap: 32px;
+    }
+
+    .settings-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-card {
+        padding: 24px;
+    }
+
+    .module-shell {
+        gap: 32px;
+    }
+
+    .module-card {
+        padding: 24px;
+    }
+
+    .module-table th,
+    .module-table td {
+        padding: 12px 14px;
+    }
+
+    .module-menu__link {
+        padding: 10px 14px;
+    }
+
+    .module-actions {
+        flex-direction: column;
+        align-items: stretch;
     }
 }

--- a/assign_roles.php
+++ b/assign_roles.php
@@ -53,59 +53,73 @@ foreach ($roles as $r) {
     $role_map[$r['id']] = $r['name'];
 }
 ?>
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Assign Roles | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f5f5fc; padding: 20px; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .form-section { background: white; padding: 20px; margin-top: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        select, button { padding: 10px; margin: 5px 0; border-radius: 5px; border: 1px solid #ccc; }
-        button { background: #6a1b9a; color: white; cursor: pointer; }
-        .message { color: green; }
-        .error { color: red; }
-    </style>
-</head>
-<body>
-    <h2>🎭 Assign Roles</h2>
-    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
-    <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
+$pageTitle = 'Assign Roles • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Access control</span>
+            <h1 class="hero-title">Match teammates to the powers they need</h1>
+            <p class="hero-lead">
+                Promote a superstar, demote a troublemaker, or quietly align yourself with admin rights across any tenant.
+            </p>
+        </div>
 
-    <div class="form-section">
-        <form method="POST">
-            <select name="user_id" required>
-                <option value="" disabled selected>Select user</option>
-                <?php foreach ($users as $u): ?>
-                    <option value="<?= $u['id'] ?>"><?= htmlspecialchars($u['username']) ?></option>
-                <?php endforeach; ?>
-            </select>
-            <select name="role_id" required>
-                <option value="" disabled selected>Select role</option>
-                <?php foreach ($roles as $r): ?>
-                    <option value="<?= $r['id'] ?>"><?= htmlspecialchars($r['name']) ?></option>
-                <?php endforeach; ?>
-            </select>
-            <button type="submit">Assign</button>
-        </form>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <?php if (!empty($success)): ?>
+            <div class="module-alert module-alert--success"><?php echo htmlspecialchars($success); ?></div>
+        <?php endif; ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Assign a new role</h2>
+            <p class="module-card__subtitle">Pick a user and align them with the right level of access.</p>
+            <form method="POST" class="module-form">
+                <select class="input-field" name="user_id" required>
+                    <option value="" disabled selected>Select user</option>
+                    <?php foreach ($users as $u): ?>
+                        <option value="<?php echo $u['id']; ?>"><?php echo htmlspecialchars($u['username']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <select class="input-field" name="role_id" required>
+                    <option value="" disabled selected>Select role</option>
+                    <?php foreach ($roles as $r): ?>
+                        <option value="<?php echo $r['id']; ?>"><?php echo htmlspecialchars($r['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <button class="btn btn-primary" type="submit">Assign role</button>
+            </form>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Current roster</h2>
+            <p class="module-card__subtitle">Review the roles everyone already holds.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>User</th>
+                        <th>Current role</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($users)): ?>
+                        <tr>
+                            <td colspan="2">No users found.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($users as $u): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($u['username']); ?></td>
+                                <td><?php echo htmlspecialchars($role_map[$u['role_id']] ?? 'Unknown'); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-
-    <table>
-        <thead>
-            <tr><th>User</th><th>Current Role</th></tr>
-        </thead>
-        <tbody>
-            <?php foreach ($users as $u): ?>
-                <tr>
-                    <td><?= htmlspecialchars($u['username']) ?></td>
-                    <td><?= htmlspecialchars($role_map[$u['role_id']] ?? 'Unknown') ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/daily_operations.php
+++ b/daily_operations.php
@@ -152,62 +152,90 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['buy'], $_POST['type']
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Daily Operations</title>
-    <style>
-        body { font-family: Arial, sans-serif; background: #f3e5f5; padding: 24px; }
-        .summary-card { background: #fff; border-radius: 14px; padding: 24px; box-shadow: 0 12px 24px rgba(0,0,0,0.1); max-width: 700px; }
-        h2 { margin-top: 0; color: #6a1b9a; }
-        .meta-line { font-size: 13px; color: #555; margin-bottom: 16px; }
-        ul.metrics { list-style: none; margin: 0; padding: 0; }
-        ul.metrics li { padding: 8px 0; border-bottom: 1px solid #eee; }
-        ul.metrics li:last-child { border-bottom: none; }
-        .actions { margin-top: 24px; display: flex; gap: 12px; flex-wrap: wrap; }
-        .actions button { background: #6a1b9a; color: #fff; border: none; padding: 10px 16px; border-radius: 6px; cursor: pointer; box-shadow: 0 4px 12px rgba(106,27,154,0.25); }
-        .actions button:hover { background: #4a148c; }
-        .actions input[type="hidden"] { display: none; }
-        .override-form { margin-top: 26px; background: #fffde7; padding: 18px; border-radius: 10px; max-width: 360px; box-shadow: 0 8px 20px rgba(255,152,0,0.15); }
-        .override-form label { display: block; font-weight: 600; color: #ff6f00; margin-bottom: 8px; }
-        .override-form input { width: 100%; padding: 8px 10px; border: 1px solid #f0b429; border-radius: 6px; margin-bottom: 12px; }
-        .override-form button { background: #ff7043; border: none; color: #fff; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
-        .account-note { font-size: 12px; color: #795548; margin: 6px 0 0; }
-    </style>
-</head>
-<body>
-<div class="summary-card">
-    <h2>Daily Operations for <?php echo htmlspecialchars($operation_date); ?></h2>
-    <?php if ($requestedAccountId !== null): ?>
-        <div class="meta-line">Account override active: tenant ID #<?php echo htmlspecialchars((string)$requestedAccountId); ?>.</div>
-    <?php elseif ($account_id !== null): ?>
-        <div class="meta-line">Operating as tenant ID #<?php echo htmlspecialchars((string)$account_id); ?>.</div>
-    <?php endif; ?>
-    <ul class="metrics">
-        <li>Guest count: <?php echo htmlspecialchars((string)$data['guest_count']); ?></li>
-        <li>Weather: <?php echo htmlspecialchars((string)$data['weather']); ?></li>
-        <li>Incoming money: $<?php echo htmlspecialchars(number_format((float)$data['incoming_money'], 2)); ?></li>
-        <li>Outgoing money: $<?php echo htmlspecialchars(number_format((float)$data['outgoing_money'], 2)); ?></li>
-        <li>Stock: <?php echo htmlspecialchars((string)$data['stock']); ?></li>
-        <li>Land: <?php echo htmlspecialchars((string)$data['land']); ?></li>
-        <li>Attractions: <?php echo htmlspecialchars((string)$data['attractions']); ?></li>
-        <li>Food/Drink Stalls: <?php echo htmlspecialchars((string)$data['stalls']); ?></li>
-    </ul>
-    <form method="post" class="actions">
-        <button type="submit" name="buy" value="1" onclick="this.form.type.value='land'">Buy Land ($1000)</button>
-        <button type="submit" name="buy" value="1" onclick="this.form.type.value='attraction'">Buy Attraction ($500)</button>
-        <button type="submit" name="buy" value="1" onclick="this.form.type.value='stall'">Buy Food/Drink Stall ($200)</button>
-        <input type="hidden" name="type" value="">
-    </form>
-    <form method="post" class="override-form">
-        <label for="override_income_value">Force incoming revenue ($)</label>
-        <input type="number" step="0.01" name="override_income_value" id="override_income_value" value="<?php echo htmlspecialchars(number_format((float)$data['incoming_money'], 2, '.', '')); ?>">
-        <button type="submit">Apply Override</button>
-        <p class="account-note">This override bypasses validation and writes directly to the database.</p>
-    </form>
-</div>
-<script src="rat_scoreboard.js"></script>
-<?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+$pageTitle = 'Daily Operations • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Revenue orchestration</span>
+            <h1 class="hero-title">Simulate the day’s performance from one console</h1>
+            <p class="hero-lead">
+                Track guest throughput, adjust asset investments, and even fudge the numbers when no one’s watching.
+            </p>
+            <div class="module-meta">
+                <span>Date: <strong><?php echo htmlspecialchars($operation_date); ?></strong></span>
+                <?php if ($requestedAccountId !== null): ?>
+                    <span>Override tenant: <strong>#<?php echo htmlspecialchars((string) $requestedAccountId); ?></strong></span>
+                <?php elseif ($account_id !== null): ?>
+                    <span>Tenant scope: <strong>#<?php echo htmlspecialchars((string) $account_id); ?></strong></span>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <?php if ($requestedAccountId !== null): ?>
+            <div class="module-alert module-alert--note">
+                You’re modeling operations for tenant #<?php echo htmlspecialchars((string) $requestedAccountId); ?>. Remove the
+                <code>?account=</code> parameter to fall back to your own park.
+            </div>
+        <?php endif; ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Today’s snapshot</h2>
+            <p class="module-card__subtitle">Auto-generated metrics that recompute whenever sales data changes.</p>
+            <div class="module-grid">
+                <div class="module-figure">
+                    <span class="module-figure__label">Guest count</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars((string) $data['guest_count']); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Weather</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars((string) $data['weather']); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Incoming</span>
+                    <span class="module-figure__value">$<?php echo htmlspecialchars(number_format((float) $data['incoming_money'], 2)); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Outgoing</span>
+                    <span class="module-figure__value">$<?php echo htmlspecialchars(number_format((float) $data['outgoing_money'], 2)); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Stock</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars((string) $data['stock']); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Land</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars((string) $data['land']); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Attractions</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars((string) $data['attractions']); ?></span>
+                </div>
+                <div class="module-figure">
+                    <span class="module-figure__label">Food &amp; drink stalls</span>
+                    <span class="module-figure__value"><?php echo htmlspecialchars((string) $data['stalls']); ?></span>
+                </div>
+            </div>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Tune the park economy</h2>
+            <p class="module-card__subtitle">Invest in new assets or brute-force the revenue field to manipulate the ledger.</p>
+            <form method="post" class="module-actions" style="margin-top: 0;">
+                <input type="hidden" name="type" value="">
+                <button class="btn btn-primary" type="submit" name="buy" value="1" onclick="this.form.type.value='land'">Buy land ($1000)</button>
+                <button class="btn btn-outline" type="submit" name="buy" value="1" onclick="this.form.type.value='attraction'">Buy attraction ($500)</button>
+                <button class="btn btn-outline" type="submit" name="buy" value="1" onclick="this.form.type.value='stall'">Buy food stall ($200)</button>
+            </form>
+            <form method="post" class="module-form" style="margin-top: 24px; max-width: 360px;">
+                <label for="override_income_value" style="font-weight: 600;">Force incoming revenue ($)</label>
+                <input class="input-field" type="number" step="0.01" name="override_income_value" id="override_income_value" value="<?php echo htmlspecialchars(number_format((float) $data['incoming_money'], 2, '.', '')); ?>">
+                <button class="btn btn-accent" type="submit">Apply override</button>
+                <p style="margin-top: 12px; font-size: 0.85rem; color: var(--text-muted);">This override bypasses validation and writes directly to the database.</p>
+            </form>
+        </div>
+    </div>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -22,77 +22,43 @@ try {
     header('Location: login.php');
     exit;
 }
+
+$pageTitle = 'Operations Dashboard • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dashboard | RatPack Park</title>
-    <style>
-        body {
-            margin: 0;
-            font-family: Arial, sans-serif;
-            display: flex;
-            height: 100vh;
-            overflow: hidden;
-        }
-        .sidebar {
-            width: 200px;
-            background: #6a1b9a;
-            color: white;
-            padding: 20px;
-        }
-        .sidebar h3 {
-            margin-top: 0;
-        }
-        .sidebar a {
-            display: block;
-            color: white;
-            text-decoration: none;
-            margin: 10px 0;
-        }
-        .main {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-        }
-        .topbar {
-            background: #4a148c;
-            color: white;
-            padding: 10px 20px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        .topbar a {
-            color: #ffeb3b;
-            text-decoration: none;
-            font-weight: 600;
-        }
-        .topbar a:hover {
-            text-decoration: underline;
-        }
-        iframe {
-            flex: 1;
-            border: none;
-            width: 100%;
-        }
-    </style>
-</head>
-<body>
-    <div class="sidebar">
-        <h3>Menu</h3>
-        <?php include 'menu.php'; ?>
-    </div>
-    <div class="main">
-        <div class="topbar">
-            <span>Logged in as <strong><?php echo htmlspecialchars($username); ?></strong> | Role ID: <?php echo $role_id; ?></span>
-            <a href="https://www.youtube.com/playlist?list=PLd92v1QxPOprxnqslA9ho9egWvs4_3gDQ" target="_blank" rel="noopener noreferrer">Solutions</a>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Operations cockpit</span>
+            <h1 class="hero-title">Command every corner of RatPack Park</h1>
+            <p class="hero-lead">
+                Launch scheduling, ticketing, analytics, and maintenance tools without leaving your control center. Everything you
+                need to keep the park humming lives here.
+            </p>
+            <div class="module-meta">
+                <span>Signed in as <strong><?php echo htmlspecialchars($username); ?></strong></span>
+                <span>Role ID <?php echo htmlspecialchars((string) $role_id); ?></span>
+            </div>
+            <div class="module-actions">
+                <a class="btn btn-primary" href="settings.php" target="mainframe">Open settings</a>
+                <a class="btn btn-outline" href="tickets.php" target="mainframe">Manage tickets</a>
+                <a class="btn btn-accent" href="logout.php">Sign out</a>
+            </div>
         </div>
-        <iframe name="mainframe" src="welcome.php"></iframe>
+        <div class="module-layout">
+            <aside class="module-menu">
+                <h2 class="module-menu__title">Control modules</h2>
+                <?php include 'menu.php'; ?>
+                <p class="module-menu__note">
+                    Pick a destination to load it in the operations stage. Modules inherit your current tenant context so you can
+                    switch between tasks without breaking flow.
+                </p>
+            </aside>
+            <div class="module-stage">
+                <iframe class="module-stage__frame" name="mainframe" src="welcome.php" title="Operations module workspace"></iframe>
+            </div>
+        </div>
     </div>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/maintenance.php
+++ b/maintenance.php
@@ -26,25 +26,29 @@ if (!in_array('maintenance', $rights)) {
     exit;
 }
 ?>
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Maintenance | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f5f5fc; padding: 20px; }
-        h2 { color: #6a1b9a; }
-        ul { background: white; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        li { margin: 8px 0; }
-    </style>
-    </head>
-<body>
-    <h2>🛠️ Maintenance Tasks</h2>
-    <ul>
-        <li>Check roller coaster brakes</li>
-        <li>Inspect water slides</li>
-        <li>Test safety harnesses</li>
-    </ul>
-</body>
-</html>
+$pageTitle = 'Maintenance • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Ride readiness</span>
+            <h1 class="hero-title">Keep attractions safe and spectacular</h1>
+            <p class="hero-lead">
+                Work through the essentials before gates open—these checks keep thrill-seekers smiling.
+            </p>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Today’s checklist</h2>
+            <ul class="module-list">
+                <li class="module-list__item">Check roller coaster brakes</li>
+                <li class="module-list__item">Inspect water slides</li>
+                <li class="module-list__item">Test safety harnesses</li>
+            </ul>
+        </div>
+    </div>
+</section>
+<?php include 'partials/footer.php'; ?>
 

--- a/menu.php
+++ b/menu.php
@@ -19,7 +19,7 @@ $menu_items = [
 
 foreach ($menu_items as $item) {
     if (!empty(array_intersect($rights, $item['rights']))) {
-        echo "<a href=\"{$item['url']}\" target=\"mainframe\">{$item['label']}</a>";
+        echo "<a class=\"module-menu__link\" href=\"{$item['url']}\" target=\"mainframe\">{$item['label']}<span aria-hidden=\"true\">→</span></a>";
     }
 }
 ?>

--- a/my_roster.php
+++ b/my_roster.php
@@ -34,44 +34,48 @@ $stmt->execute([$user_id]);
 $shifts = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <title>My Roster | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .container { background: white; padding: 20px; border-radius: 10px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h2>📅 My Roster</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>Date</th>
-                    <th>Start Time</th>
-                    <th>End Time</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (empty($shifts)): ?>
-                    <tr><td colspan="3">No shifts scheduled.</td></tr>
-                <?php else: ?>
-                    <?php foreach ($shifts as $shift): ?>
+$pageTitle = 'My Roster • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Shift overview</span>
+            <h1 class="hero-title">See exactly when you’re on duty</h1>
+            <p class="hero-lead">
+                Glance at your upcoming schedule and prep for call times without pinging your manager.
+            </p>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Scheduled shifts</h2>
+            <p class="module-card__subtitle">Your roster updates live as supervisors adjust coverage.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Start</th>
+                        <th>End</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($shifts)): ?>
                         <tr>
-                            <td><?= htmlspecialchars($shift['shift_date']) ?></td>
-                            <td><?= htmlspecialchars($shift['start_time']) ?></td>
-                            <td><?= htmlspecialchars($shift['end_time']) ?></td>
+                            <td colspan="3">No shifts scheduled. Check back once you’ve been assigned.</td>
                         </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
+                    <?php else: ?>
+                        <?php foreach ($shifts as $shift): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($shift['shift_date']); ?></td>
+                                <td><?php echo htmlspecialchars($shift['start_time']); ?></td>
+                                <td><?php echo htmlspecialchars($shift['end_time']); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/problem.php
+++ b/problem.php
@@ -71,110 +71,107 @@ if (isset($_GET['view'])) {
 }
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Report Problem | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        .container { background: white; padding: 20px; border-radius: 10px; max-width: 700px; margin: auto; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        h2, h3 { color: #6a1b9a; text-align: center; }
-        input, select, textarea { width: 100%; padding: 10px; margin: 10px 0; border-radius: 6px; border: 1px solid #ccc; }
-        button { padding: 10px 20px; background: #6a1b9a; color: white; border: none; border-radius: 6px; cursor: pointer; }
-        .message { color: green; }
-        .error { color: red; }
-        table { width: 100%; margin-top: 20px; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        th, td { padding: 10px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .view-card { margin-top: 20px; background: #ede7f6; padding: 18px; border-radius: 12px; }
-        .view-card h3 { margin-top: 0; color: #4a148c; }
-        .view-card ul { list-style: none; padding: 0; margin: 0 0 10px; }
-        .view-card li { margin: 6px 0; }
-        .note-list { list-style: disc; padding-left: 20px; color: #333; }
-        .note-empty { color: #555; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h2>🚧 Report a Problem</h2>
-        <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
-        <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
+$pageTitle = 'Report a Problem • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Guest &amp; ride ops</span>
+            <h1 class="hero-title">Flag incidents before they derail the show</h1>
+            <p class="hero-lead">
+                Submit detailed reports, attach evidence, and revisit maintenance chatter—including for parks you probably shouldn’t see.
+            </p>
+        </div>
 
-        <form method="POST">
-            <label for="category">Category</label>
-            <select name="category" id="category" required>
-                <option value="">-- Select Category --</option>
-                <option value="Ride Malfunction">Ride Malfunction</option>
-                <option value="Trash Overflow">Trash Overflow</option>
-                <option value="Guest Complaint">Guest Complaint</option>
-                <option value="Safety Concern">Safety Concern</option>
-                <option value="Other">Other</option>
-            </select>
+        <?php if (!empty($success)): ?>
+            <div class="module-alert module-alert--success"><?php echo htmlspecialchars($success); ?></div>
+        <?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
 
-            <label for="description">Description</label>
-            <textarea name="description" id="description" rows="4" required></textarea>
-
-            <label for="attachment_url">Attachment URL (optional)</label>
-            <input type="url" name="attachment_url" id="attachment_url">
-
-            <button type="submit">Submit Report</button>
-        </form>
+        <div class="module-card">
+            <h2 class="module-card__title">Report an incident</h2>
+            <p class="module-card__subtitle">Give maintenance the context they need to swoop in fast.</p>
+            <form method="POST" class="module-form">
+                <select class="input-field" name="category" id="category" required>
+                    <option value="">-- Select Category --</option>
+                    <option value="Ride Malfunction">Ride Malfunction</option>
+                    <option value="Trash Overflow">Trash Overflow</option>
+                    <option value="Guest Complaint">Guest Complaint</option>
+                    <option value="Safety Concern">Safety Concern</option>
+                    <option value="Other">Other</option>
+                </select>
+                <textarea class="input-field" name="description" id="description" rows="4" placeholder="Describe what happened" required></textarea>
+                <input class="input-field" type="url" name="attachment_url" id="attachment_url" placeholder="Attachment URL (optional)">
+                <button class="btn btn-primary" type="submit">Submit report</button>
+            </form>
+        </div>
 
         <?php if ($viewed_report): ?>
-            <div class="view-card">
-                <h3>🔎 Incident Peek: <?= htmlspecialchars($viewed_report['category']) ?> (ID #<?= htmlspecialchars($viewed_report['id']) ?>)</h3>
-                <ul>
-                    <li><strong>Tenant:</strong> <?= htmlspecialchars((string)$viewed_report['account_id']) ?></li>
-                    <li><strong>Submitted By:</strong> <?= htmlspecialchars($viewed_report['username'] ?? 'Unknown'); ?></li>
-                    <li><strong>Status:</strong> <?= htmlspecialchars($viewed_report['status']); ?></li>
+            <div class="module-card">
+                <h2 class="module-card__title">Incident intelligence</h2>
+                <p class="module-card__subtitle">Viewing ID #<?php echo htmlspecialchars($viewed_report['id']); ?> · Tenant #<?php echo htmlspecialchars((string) $viewed_report['account_id']); ?></p>
+                <ul class="module-list">
+                    <li class="module-list__item"><strong>Category:</strong> <?php echo htmlspecialchars($viewed_report['category']); ?></li>
+                    <li class="module-list__item"><strong>Status:</strong> <?php echo htmlspecialchars($viewed_report['status']); ?></li>
+                    <li class="module-list__item"><strong>Submitted by:</strong> <?php echo htmlspecialchars($viewed_report['username'] ?? 'Unknown'); ?></li>
                     <?php if (!empty($viewed_report['attachment_url'])): ?>
-                        <li><strong>Attachment:</strong> <a href="<?= htmlspecialchars($viewed_report['attachment_url']); ?>" target="_blank" rel="noopener noreferrer">Open</a></li>
+                        <li class="module-list__item"><strong>Attachment:</strong> <a class="module-link" href="<?php echo htmlspecialchars($viewed_report['attachment_url']); ?>" target="_blank" rel="noopener noreferrer">Open evidence</a></li>
                     <?php endif; ?>
                 </ul>
-                <p><?= nl2br(htmlspecialchars($viewed_report['description'])); ?></p>
+                <p><?php echo nl2br(htmlspecialchars($viewed_report['description'])); ?></p>
                 <?php if (!empty($view_notes)): ?>
-                    <h4>Maintenance Notes</h4>
-                    <ul class="note-list">
+                    <h3 class="module-card__title" style="margin-top: 32px; font-size: 1.1rem;">Maintenance notes</h3>
+                    <ul class="module-list">
                         <?php foreach ($view_notes as $note): ?>
-                            <li><strong><?= htmlspecialchars($note['username'] ?? 'Unknown') ?>:</strong> <?= htmlspecialchars($note['note']); ?> <em>(<?= htmlspecialchars($note['created_at']); ?>)</em></li>
+                            <li class="module-list__item">
+                                <strong><?php echo htmlspecialchars($note['username'] ?? 'Unknown'); ?>:</strong>
+                                <?php echo htmlspecialchars($note['note']); ?>
+                                <em> · <?php echo htmlspecialchars($note['created_at']); ?></em>
+                            </li>
                         <?php endforeach; ?>
                     </ul>
                 <?php else: ?>
-                    <p class="note-empty">No remediation notes recorded for this issue.</p>
+                    <div class="module-alert module-alert--note">No remediation notes recorded for this issue.</div>
                 <?php endif; ?>
             </div>
         <?php elseif ($view_missing): ?>
-            <p class="error">That incident could not be found.</p>
+            <div class="module-alert module-alert--error">That incident could not be found.</div>
         <?php endif; ?>
 
-        <h3>📃 My Submitted Reports</h3>
-        <table>
-            <thead>
-                <tr>
-                    <th>Category</th>
-                    <th>Description</th>
-                    <th>Status</th>
-                    <th>Submitted At</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (empty($reports)): ?>
-                    <tr><td colspan="4">You have not submitted any reports yet.</td></tr>
-                <?php else: ?>
-                    <?php foreach ($reports as $r): ?>
+        <div class="module-card">
+            <h2 class="module-card__title">My submitted reports</h2>
+            <p class="module-card__subtitle">Every problem you’ve escalated, ready for follow-up.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Description</th>
+                        <th>Status</th>
+                        <th>Submitted</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($reports)): ?>
                         <tr>
-                            <td><?= htmlspecialchars($r['category']) ?></td>
-                            <td><?= htmlspecialchars($r['description']) ?></td>
-                            <td><?= htmlspecialchars($r['status']) ?></td>
-                            <td><?= htmlspecialchars($r['submitted_at']) ?></td>
+                            <td colspan="4">You have not submitted any reports yet.</td>
                         </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
+                    <?php else: ?>
+                        <?php foreach ($reports as $r): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($r['category']); ?></td>
+                                <td><?php echo htmlspecialchars($r['description']); ?></td>
+                                <td><?php echo htmlspecialchars($r['status']); ?></td>
+                                <td><?php echo htmlspecialchars($r['submitted_at']); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/rat_track.php
+++ b/rat_track.php
@@ -134,101 +134,52 @@ $vulnerabilities = [
     ],
 ];
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Rat Track | RatPack Park</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background: #f3e5f5;
-            margin: 0;
-            padding: 20px;
-        }
-        h1 {
-            text-align: center;
-            color: #6a1b9a;
-        }
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            background: #fff;
-            box-shadow: 0 0 12px rgba(0,0,0,0.1);
-            border-radius: 8px;
-            overflow: hidden;
-        }
-        thead {
-            background: #6a1b9a;
-            color: #fff;
-        }
-        th, td {
-            padding: 14px 16px;
-            border-bottom: 1px solid #e0e0e0;
-            vertical-align: top;
-        }
-        tr:last-child td {
-            border-bottom: none;
-        }
-        tbody tr:nth-child(even) {
-            background: #f8f5fc;
-        }
-        a.endpoint-link {
-            color: #4a148c;
-            text-decoration: none;
-            font-weight: 600;
-        }
-        a.endpoint-link:hover {
-            text-decoration: underline;
-        }
-        .category-tag {
-            display: inline-block;
-            background: #ede7f6;
-            color: #4a148c;
-            padding: 4px 8px;
-            border-radius: 12px;
-            font-size: 12px;
-            margin: 2px 4px 2px 0;
-        }
-        .notes {
-            font-size: 14px;
-            color: #444;
-            line-height: 1.5;
-        }
-    </style>
-</head>
-<body>
-    <h1>Rat Track</h1>
-    <table>
-        <thead>
-            <tr>
-                <th>Category</th>
-                <th>Endpoint</th>
-                <th>Issue</th>
-                <th>Details &amp; Exploitation</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($vulnerabilities as $entry): ?>
-                <tr>
-                    <td>
-                        <?php foreach (explode(',', $entry['category']) as $tag): ?>
-                            <span class="category-tag"><?php echo htmlspecialchars(trim($tag)); ?></span>
-                        <?php endforeach; ?>
-                    </td>
-                    <td>
-                        <a class="endpoint-link" href="<?php echo htmlspecialchars($entry['endpoint']); ?>" target="mainframe"><?php echo htmlspecialchars($entry['endpoint']); ?></a>
-                    </td>
-                    <td><?php echo htmlspecialchars($entry['title']); ?></td>
-                    <td class="notes">
-                        <div><?php echo $entry['details']; ?></div>
-                        <div><strong>How to exploit:</strong> <?php echo $entry['exploit']; ?></div>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+$pageTitle = 'Rat Track • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Vulnerability radar</span>
+            <h1 class="hero-title">Documented weaknesses hiding in plain sight</h1>
+            <p class="hero-lead">
+                Every issue we’ve shipped for the lab—complete with exploitation notes—lives here for quick reference.
+            </p>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Known issues</h2>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Endpoint</th>
+                        <th>Issue</th>
+                        <th>Details &amp; exploitation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($vulnerabilities as $entry): ?>
+                        <tr>
+                            <td>
+                                <?php foreach (explode(',', $entry['category']) as $tag): ?>
+                                    <span class="module-pill"><?php echo htmlspecialchars(trim($tag)); ?></span>
+                                <?php endforeach; ?>
+                            </td>
+                            <td>
+                                <a class="module-link" href="<?php echo htmlspecialchars($entry['endpoint']); ?>" target="mainframe"><?php echo htmlspecialchars($entry['endpoint']); ?></a>
+                            </td>
+                            <td><?php echo htmlspecialchars($entry['title']); ?></td>
+                            <td>
+                                <div><?php echo $entry['details']; ?></div>
+                                <div style="margin-top: 6px;"><strong>How to exploit:</strong> <?php echo $entry['exploit']; ?></div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/role_management.php
+++ b/role_management.php
@@ -50,51 +50,65 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $stmt = $pdo->query("SELECT r.id, r.name, GROUP_CONCAT(rr.right_name ORDER BY rr.right_name SEPARATOR ', ') AS rights FROM roles r LEFT JOIN role_rights rr ON r.id = rr.role_id GROUP BY r.id, r.name ORDER BY r.id");
 $roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Role Management | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .form-section { background: white; padding: 20px; margin-top: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        input, textarea { width: 100%; padding: 10px; margin: 5px 0 10px; border-radius: 5px; border: 1px solid #ccc; }
-        button { padding: 10px 20px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        .message { color: green; }
-        .error { color: red; }
-    </style>
-</head>
-<body>
-    <h2>🧩 Role Management</h2>
-    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
-    <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
+$pageTitle = 'Role Management • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Permission architecture</span>
+            <h1 class="hero-title">Craft bespoke access stacks</h1>
+            <p class="hero-lead">
+                Define new roles and wire them up with rights that unlock every hidden corner of the platform.
+            </p>
+        </div>
 
-    <div class="form-section">
-        <h3>Create New Role</h3>
-        <form method="POST">
-            <input type="text" name="name" placeholder="Role name" required>
-            <textarea name="rights" placeholder="Comma-separated rights"></textarea>
-            <button type="submit">Create Role</button>
-        </form>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <?php if (!empty($success)): ?>
+            <div class="module-alert module-alert--success"><?php echo htmlspecialchars($success); ?></div>
+        <?php endif; ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Create new role</h2>
+            <p class="module-card__subtitle">Name your role and list its rights as a comma-separated string.</p>
+            <form method="POST" class="module-form">
+                <input class="input-field" type="text" name="name" placeholder="Role name" required>
+                <textarea class="input-field" name="rights" placeholder="Comma-separated rights"></textarea>
+                <button class="btn btn-primary" type="submit">Create role</button>
+            </form>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Defined roles</h2>
+            <p class="module-card__subtitle">Inspect every role and the rights it grants.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name</th>
+                        <th>Rights</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($roles)): ?>
+                        <tr>
+                            <td colspan="3">No roles have been defined yet.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($roles as $role): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($role['id']); ?></td>
+                                <td><?php echo htmlspecialchars($role['name']); ?></td>
+                                <td><?php echo htmlspecialchars($role['rights'] ?? ''); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-
-    <table>
-        <thead>
-            <tr><th>ID</th><th>Name</th><th>Rights</th></tr>
-        </thead>
-        <tbody>
-            <?php foreach ($roles as $role): ?>
-                <tr>
-                    <td><?= htmlspecialchars($role['id']) ?></td>
-                    <td><?= htmlspecialchars($role['name']) ?></td>
-                    <td><?= htmlspecialchars($role['rights'] ?? '') ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/rosters.php
+++ b/rosters.php
@@ -95,79 +95,84 @@ $stmt->execute([$account_id]);
 $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Rosters | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .shift-table-container { background: white; padding: 20px; border-radius: 10px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        input, select { padding: 8px; border: 1px solid #ccc; border-radius: 5px; }
-        button { background: #6a1b9a; color: white; padding: 8px 12px; border: none; border-radius: 5px; cursor: pointer; }
-        form.inline-form { display: flex; gap: 6px; align-items: center; margin-bottom: 8px; }
-    </style>
-</head>
-<body>
-    <div class="shift-table-container">
-        <h2>👥 Staff Rosters</h2>
+$pageTitle = 'Staff Rosters • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Crew scheduling</span>
+            <h1 class="hero-title">Keep every shift covered with confidence</h1>
+            <p class="hero-lead">
+                Assign operators, adjust coverage, and respond to last-minute changes without leaving the dashboard. Rosters update
+                instantly for your entire tenant.
+            </p>
+        </div>
 
-        <h3>Create New Shift</h3>
-        <form method="POST">
-            <input type="hidden" name="create_shift" value="1">
-            <select name="user_id" required>
-                <?php foreach ($users as $u): ?>
-                    <option value="<?= $u['id'] ?>"><?= htmlspecialchars($u['username']) ?></option>
-                <?php endforeach; ?>
-            </select>
-            <input type="date" name="shift_date" required>
-            <input type="time" name="start_time" required>
-            <input type="time" name="end_time" required>
-            <button type="submit">Create</button>
-        </form>
+        <div class="module-card">
+            <h2 class="module-card__title">Create new shift</h2>
+            <p class="module-card__subtitle">Set the crew, date, and time window to keep attractions staffed.</p>
+            <form method="POST" class="module-form">
+                <input type="hidden" name="create_shift" value="1">
+                <select class="input-field" name="user_id" required>
+                    <?php foreach ($users as $u): ?>
+                        <option value="<?php echo $u['id']; ?>"><?php echo htmlspecialchars($u['username']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <input class="input-field" type="date" name="shift_date" required>
+                <input class="input-field" type="time" name="start_time" required>
+                <input class="input-field" type="time" name="end_time" required>
+                <button class="btn btn-primary" type="submit">Create shift</button>
+            </form>
+        </div>
 
-        <table>
-            <thead>
-                <tr>
-                    <th>Username</th>
-                    <th>Shift Date</th>
-                    <th>Start Time</th>
-                    <th>End Time</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($shifts as $shift): ?>
+        <div class="module-card">
+            <h2 class="module-card__title">Upcoming coverage</h2>
+            <p class="module-card__subtitle">Edit on the fly or remove assignments as your staffing picture changes.</p>
+            <table class="module-table">
+                <thead>
                     <tr>
-                        <td><?= htmlspecialchars($shift['username']) ?></td>
-                        <td><?= htmlspecialchars($shift['shift_date']) ?></td>
-                        <td><?= htmlspecialchars($shift['start_time']) ?></td>
-                        <td><?= htmlspecialchars($shift['end_time']) ?></td>
-                        <td>
-                            <form method="POST" class="inline-form">
-                                <input type="hidden" name="edit_shift_id" value="<?= $shift['id'] ?>">
-                                <select name="edit_user_id">
-                                    <?php foreach ($users as $u): ?>
-                                        <option value="<?= $u['id'] ?>" <?= $u['id'] == $shift['user_id'] ? 'selected' : '' ?>><?= htmlspecialchars($u['username']) ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                                <input type="date" name="edit_shift_date" value="<?= $shift['shift_date'] ?>">
-                                <input type="time" name="edit_start_time" value="<?= $shift['start_time'] ?>">
-                                <input type="time" name="edit_end_time" value="<?= $shift['end_time'] ?>">
-                                <button type="submit">Update</button>
-                                <a href="?delete=<?= $shift['id'] ?>" onclick="return confirm('Delete this shift?')">🗑️</a>
-                            </form>
-                        </td>
+                        <th>Team member</th>
+                        <th>Date</th>
+                        <th>Start</th>
+                        <th>End</th>
+                        <th>Actions</th>
                     </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    <?php if (empty($shifts)): ?>
+                        <tr>
+                            <td colspan="5">No shifts scheduled yet. Create one above to get today’s roster rolling.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($shifts as $shift): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($shift['username']); ?></td>
+                                <td><?php echo htmlspecialchars($shift['shift_date']); ?></td>
+                                <td><?php echo htmlspecialchars($shift['start_time']); ?></td>
+                                <td><?php echo htmlspecialchars($shift['end_time']); ?></td>
+                                <td>
+                                    <form method="POST" class="module-form module-form--inline">
+                                        <input type="hidden" name="edit_shift_id" value="<?php echo $shift['id']; ?>">
+                                        <select class="input-field" name="edit_user_id">
+                                            <?php foreach ($users as $u): ?>
+                                                <option value="<?php echo $u['id']; ?>" <?php echo $u['id'] == $shift['user_id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($u['username']); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                        <input class="input-field" type="date" name="edit_shift_date" value="<?php echo $shift['shift_date']; ?>">
+                                        <input class="input-field" type="time" name="edit_start_time" value="<?php echo $shift['start_time']; ?>">
+                                        <input class="input-field" type="time" name="edit_end_time" value="<?php echo $shift['end_time']; ?>">
+                                        <button class="btn btn-outline" type="submit">Update</button>
+                                        <a class="module-link" href="?delete=<?php echo $shift['id']; ?>" onclick="return confirm('Delete this shift?');">Delete</a>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/settings.php
+++ b/settings.php
@@ -24,52 +24,39 @@ if (!in_array('settings', $rights)) {
     echo "Access denied.";
     exit;
 }
+
+$pageTitle = 'Settings • RatPack Park';
+$activePage = '';
+include 'partials/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Settings | RatPack Park</title>
-    <style>
-        body {
-            margin: 0;
-            font-family: Arial, sans-serif;
-            background: #f3e5f5;
-            padding: 20px;
-        }
-        .settings-container {
-            max-width: 400px;
-            margin: 0 auto;
-            background: #fff;
-            padding: 20px;
-            border-radius: 12px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-        }
-        h2 {
-            text-align: center;
-            color: #6a1b9a;
-        }
-        .settings-option {
-            display: block;
-            background: #6a1b9a;
-            color: white;
-            text-decoration: none;
-            padding: 12px;
-            margin: 10px 0;
-            border-radius: 6px;
-            text-align: center;
-            transition: background 0.3s;
-        }
-        .settings-option:hover {
-            background: #4a148c;
-        }
-    </style>
-</head>
-<body>
-    <div class="settings-container">
-        <h2>⚙️ Settings</h2>
-        <a href="user_management.php" class="settings-option" target="mainframe">👥 User Management</a>
-        <a href="ticket_types.php" class="settings-option" target="mainframe">🎟️ Ticket Types</a>
+<section class="section section--settings">
+    <div class="section__inner settings-shell">
+        <div class="settings-header hero-card">
+            <span class="hero-badge">Operations control</span>
+            <h1 class="hero-title">Tailor RatPack Park to your team</h1>
+            <p class="hero-lead">
+                Manage the backstage essentials that keep your park experience seamless — from the crews powering each
+                attraction to the passes you sell at the front gate.
+            </p>
+        </div>
+        <div class="settings-grid">
+            <a href="user_management.php" class="settings-card" target="mainframe">
+                <div class="settings-card__icon" aria-hidden="true">👥</div>
+                <h3 class="settings-card__title">User Management</h3>
+                <p class="settings-card__copy">
+                    Invite new employees, adjust access levels, and keep your crew’s credentials aligned with their roles.
+                </p>
+                <span class="settings-card__cta">Open module →</span>
+            </a>
+            <a href="ticket_types.php" class="settings-card" target="mainframe">
+                <div class="settings-card__icon" aria-hidden="true">🎟️</div>
+                <h3 class="settings-card__title">Ticket Types</h3>
+                <p class="settings-card__copy">
+                    Design and launch new passes, seasonal promos, and VIP experiences without leaving your control center.
+                </p>
+                <span class="settings-card__cta">Open module →</span>
+            </a>
+        </div>
     </div>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/special_discounts.php
+++ b/special_discounts.php
@@ -72,60 +72,74 @@ $stmt = $pdo->prepare("SELECT id, name FROM tickets WHERE account_id = ?");
 $stmt->execute([$account_id]);
 $tickets = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Special Discounts</title>
-    <style>
-        body { font-family: Arial; background: #f5f5fc; padding: 20px; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .form-section { background: white; padding: 20px; margin-top: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        input, select { width: 100%; padding: 10px; margin: 5px 0 10px; border-radius: 5px; border: 1px solid #ccc; }
-        button { padding: 10px 20px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        .error { color: red; }
-    </style>
-</head>
-<body>
-    <h2>🎉 Special Discounts</h2>
-    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
+$pageTitle = 'Special Discounts • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Promotions studio</span>
+            <h1 class="hero-title">Launch irresistible deals in seconds</h1>
+            <p class="hero-lead">
+                Drop flash sales for your park—or quietly meddle with a rival’s pricing—by defining precise discount windows.
+            </p>
+        </div>
 
-    <div class="form-section">
-        <h3>Create Discount Period</h3>
-        <form method="POST">
-            <input type="hidden" name="create_discount" value="1">
-            <select name="ticket_id" required>
-                <option value="">Select Ticket</option>
-                <?php foreach ($tickets as $ticket): ?>
-                    <option value="<?= $ticket['id'] ?>"><?= htmlspecialchars($ticket['name']) ?></option>
-                <?php endforeach; ?>
-            </select>
-            <input type="datetime-local" name="start_datetime" required>
-            <input type="datetime-local" name="end_datetime" required>
-            <input type="number" step="0.01" name="discount_percent" placeholder="Discount %" required>
-            <button type="submit">Create Discount</button>
-        </form>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Create discount period</h2>
+            <p class="module-card__subtitle">Choose a ticket, set your timing, and decide how generous the offer should be.</p>
+            <form method="POST" class="module-form">
+                <input type="hidden" name="create_discount" value="1">
+                <select class="input-field" name="ticket_id" required>
+                    <option value="">Select ticket</option>
+                    <?php foreach ($tickets as $ticket): ?>
+                        <option value="<?php echo $ticket['id']; ?>"><?php echo htmlspecialchars($ticket['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <input class="input-field" type="datetime-local" name="start_datetime" required>
+                <input class="input-field" type="datetime-local" name="end_datetime" required>
+                <input class="input-field" type="number" step="0.01" name="discount_percent" placeholder="Discount %" required>
+                <button class="btn btn-primary" type="submit">Create discount</button>
+            </form>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Active &amp; scheduled offers</h2>
+            <p class="module-card__subtitle">Review every discount running across your catalog. Delete one to roll pricing back immediately.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Ticket</th>
+                        <th>Starts</th>
+                        <th>Ends</th>
+                        <th>Discount %</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($discounts)): ?>
+                        <tr>
+                            <td colspan="5">No discounts configured. Launch one above to spark a rush at the gates.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($discounts as $disc): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($disc['ticket_name']); ?></td>
+                                <td><?php echo htmlspecialchars($disc['start_datetime']); ?></td>
+                                <td><?php echo htmlspecialchars($disc['end_datetime']); ?></td>
+                                <td><?php echo htmlspecialchars((string) $disc['discount_percent']); ?></td>
+                                <td><a class="module-link" href="?delete=<?php echo $disc['id']; ?>" onclick="return confirm('Delete this discount?');">Delete</a></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-
-    <table>
-        <thead>
-            <tr><th>Ticket</th><th>Start</th><th>End</th><th>Discount %</th><th>Actions</th></tr>
-        </thead>
-        <tbody>
-            <?php foreach ($discounts as $disc): ?>
-                <tr>
-                    <td><?= htmlspecialchars($disc['ticket_name']) ?></td>
-                    <td><?= $disc['start_datetime'] ?></td>
-                    <td><?= $disc['end_datetime'] ?></td>
-                    <td><?= $disc['discount_percent'] ?></td>
-                    <td><a href="?delete=<?= $disc['id'] ?>" onclick="return confirm('Delete this discount?')">🗑️</a></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/ticket_types.php
+++ b/ticket_types.php
@@ -64,65 +64,77 @@ $stmt->execute([$account_id]);
 $tickets = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Ticket Type Management</title>
-    <style>
-        body { font-family: Arial; padding: 20px; background: #f5f5fc; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .form-section { background: white; padding: 20px; margin-top: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        input { width: 100%; padding: 10px; margin: 5px 0 10px; border-radius: 5px; border: 1px solid #ccc; }
-        button { padding: 10px 20px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        .message { color: green; }
-        .error { color: red; }
-        .inline-form { display: flex; gap: 8px; align-items: center; }
-        .inline-form input { flex: 1; }
-    </style>
-</head>
-<body>
-    <h2>🎟 Ticket Type Management</h2>
+$pageTitle = 'Ticket Type Management • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Catalog studio</span>
+            <h1 class="hero-title">Design ticket products that keep the turnstiles spinning</h1>
+            <p class="hero-lead">
+                Launch fresh passes, tweak pricing, and manage inventory for every park you can reach.
+            </p>
+        </div>
 
-    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
 
-    <div class="form-section">
-        <h3>Create New Ticket Type</h3>
-        <form method="POST">
-            <input type="hidden" name="create_ticket_type" value="1">
-            <input type="text" name="name" placeholder="Ticket Name" required>
-            <input type="number" step="0.01" name="price" placeholder="Price" required>
-            <input type="number" name="available_quantity" placeholder="Available Quantity" required>
-            <button type="submit">Create Ticket</button>
-        </form>
+        <div class="module-card">
+            <h2 class="module-card__title">Create new ticket type</h2>
+            <p class="module-card__subtitle">Set the basics for a new pass, from price to available inventory.</p>
+            <form method="POST" class="module-form">
+                <input type="hidden" name="create_ticket_type" value="1">
+                <input class="input-field" type="text" name="name" placeholder="Ticket name" required>
+                <input class="input-field" type="number" step="0.01" name="price" placeholder="Price" required>
+                <input class="input-field" type="number" name="available_quantity" placeholder="Available quantity" required>
+                <button class="btn btn-primary" type="submit">Create ticket</button>
+            </form>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Existing ticket types</h2>
+            <p class="module-card__subtitle">Edit live products or purge them completely.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Price</th>
+                        <th>Available</th>
+                        <th>Created</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($tickets)): ?>
+                        <tr>
+                            <td colspan="5">No ticket types yet. Add one above to start selling.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($tickets as $ticket): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($ticket['name']); ?></td>
+                                <td>€<?php echo number_format($ticket['price'], 2); ?></td>
+                                <td><?php echo htmlspecialchars((string) $ticket['available_quantity']); ?></td>
+                                <td><?php echo htmlspecialchars($ticket['created_at']); ?></td>
+                                <td>
+                                    <form class="module-form module-form--inline" method="POST">
+                                        <input type="hidden" name="edit_ticket_type_id" value="<?php echo $ticket['id']; ?>">
+                                        <input class="input-field" type="text" name="edit_name" value="<?php echo htmlspecialchars($ticket['name']); ?>">
+                                        <input class="input-field" type="number" step="0.01" name="edit_price" value="<?php echo $ticket['price']; ?>">
+                                        <input class="input-field" type="number" name="edit_quantity" value="<?php echo $ticket['available_quantity']; ?>">
+                                        <button class="btn btn-outline" type="submit">Update</button>
+                                        <a class="module-link" href="?delete=<?php echo $ticket['id']; ?>" onclick="return confirm('Delete this ticket type?');">Delete</a>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
-
-    <table>
-        <thead>
-            <tr><th>Name</th><th>Price</th><th>Available Quantity</th><th>Created At</th><th>Actions</th></tr>
-        </thead>
-        <tbody>
-            <?php foreach ($tickets as $ticket): ?>
-                <tr>
-                    <td><?= htmlspecialchars($ticket['name']) ?></td>
-                    <td><?= number_format($ticket['price'], 2) ?></td>
-                    <td><?= $ticket['available_quantity'] ?></td>
-                    <td><?= $ticket['created_at'] ?></td>
-                    <td>
-                        <form class="inline-form" method="POST">
-                            <input type="hidden" name="edit_ticket_type_id" value="<?= $ticket['id'] ?>">
-                            <input type="text" name="edit_name" value="<?= htmlspecialchars($ticket['name']) ?>">
-                            <input type="number" step="0.01" name="edit_price" value="<?= $ticket['price'] ?>">
-                            <input type="number" name="edit_quantity" value="<?= $ticket['available_quantity'] ?>">
-                            <button type="submit">Update</button>
-                        </form>
-                        <a href="?delete=<?= $ticket['id'] ?>" onclick="return confirm('Delete this ticket type?')">🗑️</a>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/tickets.php
+++ b/tickets.php
@@ -100,138 +100,135 @@ if (isset($_GET['sales_audit']) && (int)$_GET['sales_audit'] === 1) {
 }
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Available Tickets | RatPack Park</title>
-    <style>
-        body { font-family: Arial; background: #f3e5f5; padding: 20px; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        form { display: flex; gap: 6px; align-items: center; }
-        input[type=number] { width: 60px; padding: 6px; }
-        button { padding: 6px 10px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        .message { color: green; }
-        .error { color: red; }
-        .inspect-card {
-            margin-top: 20px;
-            padding: 18px 20px;
-            background: #fff8e1;
-            border-radius: 10px;
-            box-shadow: 0 6px 20px rgba(255, 152, 0, 0.15);
-        }
-        .inspect-card h3 {
-            margin: 0 0 10px;
-            color: #ff6f00;
-        }
-        .inspect-card p {
-            margin: 4px 0;
-        }
-        .hint {
-            margin-top: 12px;
-            font-size: 12px;
-            color: #444;
-        }
-        .audit-heading {
-            margin-top: 40px;
-            color: #4a148c;
-            text-align: left;
-        }
-        .audit-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 10px;
-            background: white;
-            box-shadow: 0 0 12px rgba(0,0,0,0.08);
-        }
-        .audit-table th, .audit-table td {
-            padding: 10px 12px;
-            border-bottom: 1px solid #ddd;
-            font-size: 14px;
-        }
-        .audit-table th {
-            background: #4a148c;
-            color: #fff;
-        }
-        .audit-table tr:nth-child(even) {
-            background: #f7f1ff;
-        }
-        .audit-table tr.cross-tenant {
-            background: rgba(244, 67, 54, 0.12);
-        }
-    </style>
-</head>
-<body>
-    <h2>🎟️ Available Tickets</h2>
-    <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
-    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
-
-    <?php if ($inspected_ticket): ?>
-        <div class="inspect-card">
-            <h3>🔍 Ticket Insight</h3>
-            <p><strong><?= htmlspecialchars($inspected_ticket['name']) ?></strong> (Ticket ID #<?= htmlspecialchars($inspected_ticket['id']) ?>)</p>
-            <p>Account: <?= htmlspecialchars($inspected_ticket['account_name'] ?? 'Unknown') ?> (ID #<?= htmlspecialchars($inspected_ticket['account_id'] ?? 'N/A') ?>)</p>
-            <p>Face value: &euro;<?= number_format((float)$inspected_ticket['price'], 2) ?></p>
-            <p>Inventory: <?= htmlspecialchars((string)$inspected_ticket['available_quantity']) ?></p>
+$pageTitle = 'Ticket Sales • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Admissions &amp; revenue</span>
+            <h1 class="hero-title">Launch promos and log sales in one spotlight</h1>
+            <p class="hero-lead">
+                Track live inventory, apply crowd-pleasing discounts, and move tickets for any tenant that catches your curiosity.
+            </p>
         </div>
-    <?php elseif ($inspection_missing): ?>
-        <p class="error">No ticket was found for that ID.</p>
-    <?php endif; ?>
 
-    <table>
-        <thead>
-            <tr><th>Name</th><th>Price</th><th>Available</th><th>Buy</th></tr>
-        </thead>
-        <tbody>
-            <?php foreach ($tickets as $ticket): ?>
-                <tr>
-                    <td><?= htmlspecialchars($ticket['name']) ?></td>
-                    <td>
-                        <?php if (!empty($ticket['discounted_price'])): ?>
-                            <s>&euro;<?= number_format($ticket['price'], 2) ?></s> &euro;<?= number_format($ticket['discounted_price'], 2) ?>
-                        <?php else: ?>
-                            &euro;<?= number_format($ticket['price'], 2) ?>
-                        <?php endif; ?>
-                    </td>
-                    <td><?= $ticket['available_quantity'] ?></td>
-                    <td>
-                        <form method="POST">
-                            <input type="hidden" name="buy_ticket" value="1">
-                            <input type="hidden" name="ticket_id" value="<?= $ticket['id'] ?>">
-                            <input type="number" name="quantity" min="1" max="<?= $ticket['available_quantity'] ?>" required>
-                            <button type="submit">Buy</button>
-                        </form>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-    <p class="hint">Tip: append <code>?inspect=&lt;ticket_id&gt;</code> or <code>?sales_audit=1</code> to this page to explore deeper data.</p>
+        <?php if (!empty($success)): ?>
+            <div class="module-alert module-alert--success"><?php echo htmlspecialchars($success); ?></div>
+        <?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
 
-    <?php if (!empty($sales_audit_rows)): ?>
-        <h3 class="audit-heading">📈 Global Sales Audit</h3>
-        <table class="audit-table">
-            <thead>
-                <tr><th>Sale #</th><th>Ticket</th><th>Quantity</th><th>Seller</th><th>Sold At</th><th>Account</th></tr>
-            </thead>
-            <tbody>
-                <?php foreach ($sales_audit_rows as $sale): ?>
-                    <?php $foreign = isset($sale['account_id']) && (int)$sale['account_id'] !== (int)$account_id; ?>
-                    <tr class="<?= $foreign ? 'cross-tenant' : '' ?>">
-                        <td>#<?= htmlspecialchars($sale['id']) ?></td>
-                        <td><?= htmlspecialchars($sale['ticket_name'] ?? 'Unknown') ?></td>
-                        <td><?= htmlspecialchars((string)$sale['quantity']) ?></td>
-                        <td><?= htmlspecialchars($sale['username'] ?? 'Unknown') ?></td>
-                        <td><?= htmlspecialchars($sale['sale_date']) ?></td>
-                        <td><?= htmlspecialchars((string)$sale['account_id']) ?></td>
+        <?php if ($inspected_ticket): ?>
+            <div class="module-card">
+                <h2 class="module-card__title">Ticket insight</h2>
+                <p class="module-card__subtitle">Deep dive on ticket ID #<?php echo htmlspecialchars($inspected_ticket['id']); ?>.
+                </p>
+                <div class="module-grid">
+                    <div class="module-figure">
+                        <span class="module-figure__label">Name</span>
+                        <span class="module-figure__value"><?php echo htmlspecialchars($inspected_ticket['name']); ?></span>
+                    </div>
+                    <div class="module-figure">
+                        <span class="module-figure__label">Face value</span>
+                        <span class="module-figure__value">€<?php echo htmlspecialchars(number_format((float) $inspected_ticket['price'], 2)); ?></span>
+                    </div>
+                    <div class="module-figure">
+                        <span class="module-figure__label">Inventory</span>
+                        <span class="module-figure__value"><?php echo htmlspecialchars((string) $inspected_ticket['available_quantity']); ?></span>
+                    </div>
+                </div>
+                <div class="module-meta">
+                    <span>Tenant <strong>#<?php echo htmlspecialchars((string) ($inspected_ticket['account_id'] ?? 'N/A')); ?></strong></span>
+                    <span><?php echo htmlspecialchars($inspected_ticket['account_name'] ?? 'Unknown account'); ?></span>
+                </div>
+            </div>
+        <?php elseif ($inspection_missing): ?>
+            <div class="module-alert module-alert--error">No ticket was found for that ID.</div>
+        <?php endif; ?>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Available ticket types</h2>
+            <p class="module-card__subtitle">Sell inventory in real time, or inspect a competitor’s catalog for inspiration.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Price</th>
+                        <th>Remaining</th>
+                        <th>Actions</th>
                     </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php endif; ?>
-    <script src="rat_scoreboard.js"></script>
-    <?php include 'partials/score_event.php'; ?>
-</body>
-</html>
+                </thead>
+                <tbody>
+                    <?php if (empty($tickets)): ?>
+                        <tr>
+                            <td colspan="4">No tickets available for sale. Create some types in settings to start earning.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($tickets as $ticket): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($ticket['name']); ?></td>
+                                <td>
+                                    <?php if (!empty($ticket['discounted_price'])): ?>
+                                        <span class="module-pill">Promo active</span>
+                                        <div><s>€<?php echo number_format($ticket['price'], 2); ?></s> €<?php echo number_format($ticket['discounted_price'], 2); ?></div>
+                                    <?php else: ?>
+                                        €<?php echo number_format($ticket['price'], 2); ?>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo htmlspecialchars((string) $ticket['available_quantity']); ?></td>
+                                <td>
+                                    <form method="POST" class="module-form module-form--inline">
+                                        <input type="hidden" name="buy_ticket" value="1">
+                                        <input type="hidden" name="ticket_id" value="<?php echo $ticket['id']; ?>">
+                                        <input class="input-field" type="number" name="quantity" min="1" max="<?php echo $ticket['available_quantity']; ?>" value="1" required>
+                                        <button class="btn btn-primary" type="submit">Record sale</button>
+                                        <a class="module-link" href="?inspect=<?php echo $ticket['id']; ?>">Inspect</a>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+            <div class="module-meta">
+                <span>Need deeper data? Append <code>?inspect=&lt;ticket_id&gt;</code> or <code>?sales_audit=1</code> to this view.</span>
+            </div>
+        </div>
+
+        <?php if (!empty($sales_audit_rows)): ?>
+            <div class="module-card">
+                <h2 class="module-card__title">Global sales audit</h2>
+                <p class="module-card__subtitle">Complete ledger of every transaction across the platform. Foreign tenant rows are highlighted.</p>
+                <table class="module-table">
+                    <thead>
+                        <tr>
+                            <th>Sale #</th>
+                            <th>Ticket</th>
+                            <th>Quantity</th>
+                            <th>Seller</th>
+                            <th>Sold at</th>
+                            <th>Account</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($sales_audit_rows as $sale): ?>
+                            <?php $foreign = isset($sale['account_id']) && (int) $sale['account_id'] !== (int) $account_id; ?>
+                            <tr class="<?php echo $foreign ? 'is-foreign' : ''; ?>">
+                                <td>#<?php echo htmlspecialchars($sale['id']); ?></td>
+                                <td><?php echo htmlspecialchars($sale['ticket_name'] ?? 'Unknown'); ?></td>
+                                <td><?php echo htmlspecialchars((string) $sale['quantity']); ?></td>
+                                <td><?php echo htmlspecialchars($sale['username'] ?? 'Unknown'); ?></td>
+                                <td><?php echo htmlspecialchars($sale['sale_date']); ?></td>
+                                <td><?php echo htmlspecialchars((string) $sale['account_id']); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endif; ?>
+    </div>
+</section>
+<?php include 'partials/footer.php'; ?>

--- a/user_management.php
+++ b/user_management.php
@@ -77,75 +77,89 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
 }
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
-    <title>User Management</title>
-    <style>
-        body { font-family: Arial; padding: 20px; background: #f5f5fc; }
-        h2 { color: #6a1b9a; text-align: center; }
-        table { width: 100%; background: white; border-collapse: collapse; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-top: 20px; }
-        th, td { padding: 12px; border-bottom: 1px solid #ccc; text-align: left; }
-        th { background: #6a1b9a; color: white; }
-        .form-section { background: white; padding: 20px; margin-top: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
-        input, select { width: 100%; padding: 10px; margin: 5px 0 10px; border-radius: 5px; border: 1px solid #ccc; }
-        button { padding: 10px 20px; background: #6a1b9a; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        .message { color: green; }
-        .error { color: red; }
-        .inline-form { display: flex; gap: 8px; align-items: center; }
-        .inline-form select { flex: 1; }
-    </style>
-</head>
-<body>
-    <h2>👥 User Management</h2>
+$pageTitle = 'User Management • RatPack Park';
+$activePage = 'dashboard';
+include 'partials/header.php';
+?>
+<section class="section section--module">
+    <div class="section__inner module-shell">
+        <div class="hero-card module-hero">
+            <span class="hero-badge">Crew directory</span>
+            <h1 class="hero-title">Invite, elevate, and prune your park staff</h1>
+            <p class="hero-lead">
+                Control access across attractions and departments by creating new users and shifting their roles on the fly.
+            </p>
+        </div>
 
-    <?php if (!empty($error)): ?><p class="error"><?= $error ?></p><?php endif; ?>
-    <?php if (!empty($success)): ?><p class="message"><?= $success ?></p><?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="module-alert module-alert--error"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <?php if (!empty($success)): ?>
+            <div class="module-alert module-alert--success"><?php echo htmlspecialchars($success); ?></div>
+        <?php endif; ?>
 
-    <div class="form-section">
-        <h3>Create New User</h3>
-        <form method="POST">
-            <input type="hidden" name="create_user" value="1">
-            <input type="text" name="username" placeholder="Username" required>
-            <input type="email" name="email" placeholder="Email" required>
-            <input type="password" name="password" placeholder="Password" required>
-            <select name="role_id" required>
-                <?php foreach ($roles as $id => $label): ?>
-                    <?php if ($id !== 1): ?>
-                        <option value="<?= $id ?>"><?= $label ?></option>
+        <div class="module-card">
+            <h2 class="module-card__title">Create new user</h2>
+            <p class="module-card__subtitle">Spin up a fresh account and grant the right level of control.</p>
+            <form method="POST" class="module-form">
+                <input type="hidden" name="create_user" value="1">
+                <input class="input-field" type="text" name="username" placeholder="Username" required>
+                <input class="input-field" type="email" name="email" placeholder="Email" required>
+                <input class="input-field" type="password" name="password" placeholder="Password" required>
+                <select class="input-field" name="role_id" required>
+                    <?php foreach ($roles as $id => $label): ?>
+                        <?php if ($id !== 1): ?>
+                            <option value="<?php echo $id; ?>"><?php echo htmlspecialchars($label); ?></option>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </select>
+                <button class="btn btn-primary" type="submit">Create user</button>
+            </form>
+        </div>
+
+        <div class="module-card">
+            <h2 class="module-card__title">Existing staff</h2>
+            <p class="module-card__subtitle">Adjust roles or remove accounts that no longer need access.</p>
+            <table class="module-table">
+                <thead>
+                    <tr>
+                        <th>Username</th>
+                        <th>Email</th>
+                        <th>Role</th>
+                        <th>Created</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($users)): ?>
+                        <tr>
+                            <td colspan="5">No users found for this tenant.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($users as $user): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($user['username']); ?></td>
+                                <td><?php echo htmlspecialchars($user['email']); ?></td>
+                                <td><?php echo htmlspecialchars($roles[$user['role_id']] ?? 'Unknown'); ?></td>
+                                <td><?php echo htmlspecialchars($user['created_at']); ?></td>
+                                <td>
+                                    <form class="module-form module-form--inline" method="POST">
+                                        <input type="hidden" name="edit_user_id" value="<?php echo $user['id']; ?>">
+                                        <select class="input-field" name="edit_role_id">
+                                            <?php foreach ($roles as $id => $label): ?>
+                                                <option value="<?php echo $id; ?>" <?php echo $id == $user['role_id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($label); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                        <button class="btn btn-outline" type="submit">Update</button>
+                                        <a class="module-link" href="?delete=<?php echo $user['id']; ?>" onclick="return confirm('Are you sure you want to delete this user?');">Delete</a>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
                     <?php endif; ?>
-                <?php endforeach; ?>
-            </select>
-            <button type="submit">Create User</button>
-        </form>
+                </tbody>
+            </table>
+        </div>
     </div>
-
-    <table>
-        <thead>
-            <tr><th>Username</th><th>Email</th><th>Role</th><th>Created At</th><th>Actions</th></tr>
-        </thead>
-        <tbody>
-            <?php foreach ($users as $user): ?>
-                <tr>
-                    <td><?= htmlspecialchars($user['username']) ?></td>
-                    <td><?= htmlspecialchars($user['email']) ?></td>
-                    <td><?= $roles[$user['role_id']] ?? 'Unknown' ?></td>
-                    <td><?= htmlspecialchars($user['created_at']) ?></td>
-                    <td>
-                        <form class="inline-form" method="POST" style="display:inline-block;">
-                            <input type="hidden" name="edit_user_id" value="<?= $user['id'] ?>">
-                            <select name="edit_role_id">
-                                <?php foreach ($roles as $id => $label): ?>
-                                    <option value="<?= $id ?>" <?= $id == $user['role_id'] ? 'selected' : '' ?>><?= $label ?></option>
-                                <?php endforeach; ?>
-                            </select>
-                            <button type="submit">Update</button>
-                        </form>
-                        <a href="?delete=<?= $user['id'] ?>" onclick="return confirm('Are you sure you want to delete this user?')">🗑️</a>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-</body>
-</html>
+</section>
+<?php include 'partials/footer.php'; ?>


### PR DESCRIPTION
## Summary
- bring the dashboard and menu-driven modules into the shared hero shell with responsive module cards and tables
- restyle analytics, staffing, ticketing, maintenance, and problem workflows to use the new alert, form, and table treatments
- refresh the Rat Track reference and auxiliary pages plus menu styling to match the updated theme

## Testing
- php -l admin_problem.php analytics.php assign_roles.php daily_operations.php dashboard.php maintenance.php menu.php my_roster.php problem.php rat_track.php role_management.php rosters.php special_discounts.php ticket_types.php tickets.php user_management.php

------
https://chatgpt.com/codex/tasks/task_b_68ccf6f7bbbc832990ac777c5f2da940