### PR TITLE
Add Google Analytics tag to site header

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -26,6 +26,30 @@ body {
     min-height: 100vh;
 }
 
+html.is-embedded,
+html.is-embedded body {
+    background: none;
+}
+
+html.is-embedded body {
+    min-height: auto;
+}
+
+html.is-embedded .aurora,
+html.is-embedded .top-nav,
+html.is-embedded .site-footer {
+    display: none;
+}
+
+html.is-embedded .app-shell {
+    min-height: auto;
+    box-shadow: none;
+}
+
+html.is-embedded .main-content {
+    padding: 0 0 32px;
+}
+
 .aurora {
     position: fixed;
     inset: 0;
@@ -466,8 +490,109 @@ body {
     box-shadow: 0 18px 45px rgba(27, 17, 85, 0.1);
 }
 
+.module-card--speedrun {
+    background: linear-gradient(135deg, rgba(93, 44, 168, 0.12), rgba(255, 95, 162, 0.12));
+    border: 1px solid rgba(93, 44, 168, 0.18);
+}
+
 .module-card + .module-card {
     margin-top: 24px;
+}
+
+.speedrun-status {
+    list-style: none;
+    margin: 20px 0 0;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.speedrun-status li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.65);
+    font-weight: 600;
+}
+
+.speedrun-status li span:last-child {
+    font-variant-numeric: tabular-nums;
+    font-weight: 500;
+}
+
+.speedrun-status li.speedrun-status--unlocked {
+    background: rgba(76, 175, 80, 0.18);
+    color: #1b5e20;
+}
+
+.speedrun-status li.speedrun-status--locked {
+    background: rgba(93, 44, 168, 0.1);
+    color: var(--park-purple);
+}
+
+.guide-details {
+    position: relative;
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+.guide-details__content {
+    position: relative;
+    z-index: 1;
+}
+
+.guide-details__time {
+    margin-top: 10px;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--park-purple);
+}
+
+.guide-details__mask {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 20px;
+    text-align: center;
+    background: rgba(32, 0, 64, 0.82);
+    color: #f9f5ff;
+    backdrop-filter: blur(6px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.guide-details__mask strong {
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+}
+
+.guide-details__mask p {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.guide-details--locked .guide-details__content {
+    filter: blur(8px);
+    user-select: none;
+    pointer-events: none;
+}
+
+.guide-details--locked .guide-details__mask {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.guide-details__mask-hint {
+    font-size: 0.8rem;
+    opacity: 0.85;
 }
 
 .module-card__title {

--- a/menu.php
+++ b/menu.php
@@ -13,7 +13,7 @@ $menu_items = [
     ['label' => 'Role Management', 'url' => 'role_management.php', 'rights' => ['roles_management']],
     ['label' => 'Assign Roles', 'url' => 'assign_roles.php', 'rights' => ['user_management']],
     ['label' => 'Daily Operations', 'url' => 'daily_operations.php', 'rights' => ['daily_operations']],
-    ['label' => 'Rat Track', 'url' => 'rat_track.php', 'rights' => ['logout']],
+    ['label' => '{{SPOILERS}} IDOR and BAC guide', 'url' => 'rat_track.php', 'rights' => ['logout']],
     ['label' => 'Logout', 'url' => 'logout.php', 'rights' => ['logout']],
 ];
 

--- a/partials/header.php
+++ b/partials/header.php
@@ -12,9 +12,72 @@ if (!isset($activePage)) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($pageTitle); ?></title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TMQL73DM4R"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-TMQL73DM4R');
+    </script>
     <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
+<script>
+    (function () {
+        try {
+            if (window.self !== window.top) {
+                document.documentElement.classList.add('is-embedded');
+                document.body.classList.add('is-embedded');
+            }
+        } catch (err) {
+            document.documentElement.classList.add('is-embedded');
+            document.body.classList.add('is-embedded');
+        }
+    })();
+</script>
+<?php
+$tenantMeta = [
+    'tenantId' => null,
+    'startedAt' => null,
+    'speedrun' => new stdClass(),
+    'history' => [],
+];
+
+if (session_status() === PHP_SESSION_ACTIVE) {
+    if (isset($_SESSION['temporary_tenant_id'])) {
+        $tenantMeta['tenantId'] = (int)$_SESSION['temporary_tenant_id'];
+    }
+    if (isset($_SESSION['temporary_tenant_started_at'])) {
+        $tenantMeta['startedAt'] = (int)$_SESSION['temporary_tenant_started_at'];
+    }
+
+    if (
+        $tenantMeta['tenantId'] !== null &&
+        isset($_SESSION['rat_speedrun']) &&
+        is_array($_SESSION['rat_speedrun']) &&
+        isset($_SESSION['rat_speedrun'][$tenantMeta['tenantId']]) &&
+        is_array($_SESSION['rat_speedrun'][$tenantMeta['tenantId']])
+    ) {
+        $speedrunRecord = $_SESSION['rat_speedrun'][$tenantMeta['tenantId']];
+        if (!empty($speedrunRecord['categories']) && is_array($speedrunRecord['categories'])) {
+            $tenantMeta['speedrun'] = $speedrunRecord['categories'];
+        }
+        if (!empty($speedrunRecord['history']) && is_array($speedrunRecord['history'])) {
+            $tenantMeta['history'] = array_values(array_slice($speedrunRecord['history'], -10));
+        }
+    }
+}
+
+$tenantMetaJson = json_encode($tenantMeta, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+if ($tenantMetaJson === false) {
+    $tenantMetaJson = '{}';
+}
+?>
+<script>
+    window.__ratTenantMeta = <?php echo $tenantMetaJson; ?>;
+</script>
 <div class="aurora"></div>
 <div class="app-shell">
     <header class="top-nav">

--- a/rat_helpers.php
+++ b/rat_helpers.php
@@ -8,11 +8,58 @@ if (!function_exists('rat_track_add_score_event')) {
         if (!isset($_SESSION['rat_score_events']) || !is_array($_SESSION['rat_score_events'])) {
             $_SESSION['rat_score_events'] = [];
         }
-        $_SESSION['rat_score_events'][] = [
+        $now = time();
+        $event = [
             'type' => $type,
             'message' => $message,
             'points' => $points,
-            'ts' => time(),
+            'ts' => $now,
         ];
+
+        $tenantId = $_SESSION['temporary_tenant_id'] ?? null;
+        if ($tenantId !== null) {
+            $event['tenantId'] = (int)$tenantId;
+        }
+
+        $startedAt = $_SESSION['temporary_tenant_started_at'] ?? null;
+        if ($startedAt !== null) {
+            $elapsed = max(0, $now - (int)$startedAt);
+            $event['elapsed'] = $elapsed;
+        }
+
+        $_SESSION['rat_score_events'][] = $event;
+
+        if ($tenantId !== null) {
+            if (!isset($_SESSION['rat_speedrun']) || !is_array($_SESSION['rat_speedrun'])) {
+                $_SESSION['rat_speedrun'] = [];
+            }
+            if (!isset($_SESSION['rat_speedrun'][$tenantId]) || !is_array($_SESSION['rat_speedrun'][$tenantId])) {
+                $_SESSION['rat_speedrun'][$tenantId] = [
+                    'history' => [],
+                    'categories' => [],
+                ];
+            }
+
+            $bucket =& $_SESSION['rat_speedrun'][$tenantId];
+            $bucket['history'][] = [
+                'type' => $type,
+                'message' => $message,
+                'points' => $points,
+                'ts' => $now,
+                'elapsed' => $event['elapsed'] ?? null,
+            ];
+            if (count($bucket['history']) > 50) {
+                $bucket['history'] = array_slice($bucket['history'], -50);
+            }
+
+            $normalizedType = strtoupper($type);
+            if (!isset($bucket['categories'][$normalizedType]) && isset($event['elapsed'])) {
+                $bucket['categories'][$normalizedType] = [
+                    'elapsed' => $event['elapsed'],
+                    'ts' => $now,
+                    'message' => $message,
+                ];
+            }
+        }
     }
 }

--- a/rat_scoreboard.js
+++ b/rat_scoreboard.js
@@ -1,17 +1,42 @@
 (function () {
+    const isEmbedded = (function () {
+        try {
+            return window.self !== window.top;
+        } catch (err) {
+            return true;
+        }
+    })();
+
+    if (isEmbedded || document.documentElement.classList.contains('is-embedded')) {
+        return;
+    }
+
     if (window.__ratScoreboardLoaded) {
         return;
     }
     window.__ratScoreboardLoaded = true;
 
-    const SCORE_KEY = 'ratTrackScore';
-    const MAX_KEY = 'ratTrackMaxScore';
+    const meta = window.__ratTenantMeta || {};
+    const rawTenantId = meta && Object.prototype.hasOwnProperty.call(meta, 'tenantId') ? meta.tenantId : null;
+    const tenantId = rawTenantId === null || rawTenantId === undefined ? null : String(rawTenantId);
+    const KEY_PREFIX = tenantId ? `ratpack:${tenantId}:` : 'ratpack:global:';
+    const SCORE_KEY = `${KEY_PREFIX}score`;
+    const MAX_KEY = `${KEY_PREFIX}max`;
+    const HISTORY_KEY = `${KEY_PREFIX}history`;
+    const SPEEDRUN_KEY = `${KEY_PREFIX}speedrun`;
+    const RUN_KEY = `${KEY_PREFIX}runStart`;
     const pendingQueue = Array.isArray(window.__ratScoreboardQueue) ? window.__ratScoreboardQueue : [];
+    const runStartMeta = typeof meta.startedAt === 'number' ? meta.startedAt : null;
+    const speedrunSeed = meta && meta.speedrun && typeof meta.speedrun === 'object' ? meta.speedrun : {};
+    const historySeed = Array.isArray(meta.history) ? meta.history : [];
     let container;
     let scoreValue;
     let maxValue;
     let lastEvent;
     let lastEventWrapper;
+    let timerValue;
+    let historyList;
+    const speedrunNodes = {};
 
     function readStorage(key) {
         try {
@@ -27,6 +52,38 @@
         } catch (err) {
             // ignore storage issues (e.g. Safari private mode)
         }
+    }
+
+    function parseJson(value) {
+        if (typeof value !== 'string') {
+            return null;
+        }
+        try {
+            return JSON.parse(value);
+        } catch (err) {
+            return null;
+        }
+    }
+
+    function formatElapsed(seconds) {
+        if (!Number.isFinite(seconds) || seconds < 0) {
+            return '--:--';
+        }
+        const whole = Math.floor(seconds);
+        const hrs = Math.floor(whole / 3600);
+        const mins = Math.floor((whole % 3600) / 60);
+        const secs = whole % 60;
+        if (hrs > 0) {
+            return `${hrs}:${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+        }
+        return `${mins}:${String(secs).padStart(2, '0')}`;
+    }
+
+    function sanitizeText(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
     }
 
     function injectStyles() {
@@ -80,6 +137,9 @@
             #rat-scoreboard .rat-scoreboard-metric strong {
                 font-size: 20px;
             }
+            #rat-scoreboard .rat-scoreboard-metric[data-rat-timer-row] strong {
+                font-variant-numeric: tabular-nums;
+            }
             #rat-scoreboard .rat-scoreboard-last {
                 margin-top: 12px;
                 font-size: 13px;
@@ -108,6 +168,84 @@
                 border-radius: 999px;
                 background: rgba(255, 255, 255, 0.18);
             }
+            #rat-scoreboard .rat-scoreboard-challenge {
+                margin-top: 10px;
+                padding: 10px;
+                border-radius: 10px;
+                background: rgba(255, 255, 255, 0.08);
+            }
+            #rat-scoreboard .rat-scoreboard-challenge-title {
+                font-size: 12px;
+                text-transform: uppercase;
+                letter-spacing: 0.06em;
+                opacity: 0.85;
+                margin-bottom: 8px;
+            }
+            #rat-scoreboard .rat-scoreboard-challenge-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: grid;
+                gap: 6px;
+            }
+            #rat-scoreboard .rat-scoreboard-challenge-list li {
+                display: flex;
+                justify-content: space-between;
+                font-size: 13px;
+                align-items: center;
+            }
+            #rat-scoreboard .rat-scoreboard-challenge-list li .label {
+                font-weight: 600;
+            }
+            #rat-scoreboard .rat-scoreboard-challenge-list li .value {
+                font-variant-numeric: tabular-nums;
+                padding: 2px 8px;
+                border-radius: 999px;
+                background: rgba(255, 255, 255, 0.15);
+            }
+            #rat-scoreboard .rat-scoreboard-challenge-list li.rat-scoreboard-speedrun-unlocked .value {
+                background: rgba(76, 175, 80, 0.25);
+                color: #c8f7c5;
+            }
+            #rat-scoreboard .rat-scoreboard-history {
+                margin-top: 12px;
+                background: rgba(255, 255, 255, 0.08);
+                border-radius: 10px;
+                padding: 10px;
+            }
+            #rat-scoreboard .rat-scoreboard-history-title {
+                font-size: 12px;
+                text-transform: uppercase;
+                letter-spacing: 0.06em;
+                margin-bottom: 6px;
+                opacity: 0.75;
+            }
+            #rat-scoreboard .rat-scoreboard-history-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: grid;
+                gap: 6px;
+            }
+            #rat-scoreboard .rat-scoreboard-history-list li {
+                display: flex;
+                flex-direction: column;
+                gap: 2px;
+                font-size: 12px;
+                background: rgba(12, 0, 24, 0.35);
+                border-radius: 8px;
+                padding: 6px 8px;
+            }
+            #rat-scoreboard .rat-scoreboard-history-list li strong {
+                font-size: 13px;
+            }
+            #rat-scoreboard .rat-scoreboard-history-list li .rat-scoreboard-history-meta {
+                display: flex;
+                justify-content: space-between;
+                font-size: 11px;
+                opacity: 0.8;
+                font-variant-numeric: tabular-nums;
+            }
             #rat-scoreboard .rat-scoreboard-footer {
                 margin-top: 10px;
                 font-size: 11px;
@@ -127,7 +265,7 @@
         const el = document.createElement('div');
         el.id = 'rat-scoreboard';
         el.innerHTML = `
-            <div class="rat-scoreboard-title">Rat Track <span>Scoreboard</span></div>
+            <div class="rat-scoreboard-title">Scoreboard <span>Speedrun</span></div>
             <div class="rat-scoreboard-metric">
                 <span>Current Score</span>
                 <strong data-rat-score>0</strong>
@@ -136,13 +274,42 @@
                 <span class="rat-scoreboard-max-label">Best Run<span>🏆</span></span>
                 <strong data-rat-max>0</strong>
             </div>
+            <div class="rat-scoreboard-metric" data-rat-timer-row>
+                <span>Run Timer</span>
+                <strong data-rat-timer>--:--</strong>
+            </div>
+            <div class="rat-scoreboard-challenge">
+                <div class="rat-scoreboard-challenge-title">BAC &amp; IDOR Speedrun</div>
+                <ul class="rat-scoreboard-challenge-list">
+                    <li data-speedrun-item="IDOR">
+                        <span class="label">IDOR</span>
+                        <span class="value" data-rat-speedrun="IDOR">Locked</span>
+                    </li>
+                    <li data-speedrun-item="BAC">
+                        <span class="label">BAC</span>
+                        <span class="value" data-rat-speedrun="BAC">Locked</span>
+                    </li>
+                </ul>
+            </div>
             <div class="rat-scoreboard-last" data-rat-last>Explore the app to unlock findings.</div>
-            <div class="rat-scoreboard-footer">Find IDORs &amp; BAC to climb the board.</div>
+            <div class="rat-scoreboard-history">
+                <div class="rat-scoreboard-history-title">Recent Findings</div>
+                <ul class="rat-scoreboard-history-list" data-rat-history></ul>
+            </div>
+            <div class="rat-scoreboard-footer">Speedrun every BAC &amp; IDOR bug to beat your best time.</div>
         `;
         scoreValue = el.querySelector('[data-rat-score]');
         maxValue = el.querySelector('[data-rat-max]');
         lastEvent = el.querySelector('[data-rat-last]');
         lastEventWrapper = lastEvent;
+        timerValue = el.querySelector('[data-rat-timer]');
+        historyList = el.querySelector('[data-rat-history]');
+        el.querySelectorAll('[data-rat-speedrun]').forEach((node) => {
+            const key = sanitizeText(node.getAttribute('data-rat-speedrun')).toUpperCase();
+            if (key) {
+                speedrunNodes[key] = node;
+            }
+        });
         return el;
     }
 
@@ -151,6 +318,10 @@
         score: 0,
         max: 0,
         queue: pendingQueue,
+        history: [],
+        speedrunTimes: {},
+        runStart: runStartMeta || null,
+        timerHandle: null,
         init() {
             injectStyles();
             container = createContainer();
@@ -159,6 +330,9 @@
             const storedMax = parseInt(readStorage(MAX_KEY), 10);
             this.score = Number.isFinite(storedScore) ? storedScore : 0;
             this.max = Number.isFinite(storedMax) ? storedMax : 0;
+            this.loadHistory();
+            this.loadSpeedrun();
+            this.ensureRunStart();
             this.ready = true;
             this.updateUI();
             if (Array.isArray(this.queue) && this.queue.length) {
@@ -188,7 +362,10 @@
                     container.classList.add('rat-scoreboard-new-max');
                 }
             }
-            writeStorage(SCORE_KEY, this.score);
+            this.captureRunStart(event);
+            this.recordHistory(event);
+            this.updateSpeedrun(event);
+            this.persistState();
             this.updateUI(event);
         },
         updateUI(lastEventData) {
@@ -200,8 +377,11 @@
             }
             if (lastEventWrapper) {
                 if (lastEventData) {
-                    const summary = lastEventData.type ? `${lastEventData.type}: ${lastEventData.message}` : lastEventData.message;
-                    lastEventWrapper.textContent = summary || 'New activity recorded.';
+                    const baseSummary = lastEventData.type ? `${lastEventData.type}: ${lastEventData.message}` : lastEventData.message;
+                    const elapsedLabel = Number.isFinite(lastEventData.elapsed)
+                        ? ` (T+${formatElapsed(lastEventData.elapsed)})`
+                        : '';
+                    lastEventWrapper.textContent = sanitizeText(baseSummary || 'New activity recorded.') + elapsedLabel;
                     lastEventWrapper.classList.add('rat-scoreboard-highlight');
                     setTimeout(() => {
                         lastEventWrapper.classList.remove('rat-scoreboard-highlight');
@@ -210,6 +390,244 @@
                 } else if (!lastEventWrapper.dataset.hadEvent) {
                     lastEventWrapper.textContent = 'Explore the app to unlock findings.';
                 }
+            }
+            this.renderHistory();
+            this.renderSpeedrun();
+            this.ensureTimer();
+        },
+        loadHistory() {
+            const stored = parseJson(readStorage(HISTORY_KEY));
+            const combined = [];
+            if (Array.isArray(stored)) {
+                combined.push(...stored);
+            }
+            if (historySeed.length) {
+                combined.push(...historySeed);
+            }
+            const seen = new Set();
+            const normalized = combined.filter((entry) => {
+                if (!entry || typeof entry !== 'object') {
+                    return false;
+                }
+                const key = `${entry.type || ''}|${entry.message || ''}|${entry.ts || ''}`;
+                if (seen.has(key)) {
+                    return false;
+                }
+                seen.add(key);
+                return true;
+            });
+            normalized.sort((a, b) => {
+                const aTs = Number.isFinite(Number(a.ts)) ? Number(a.ts) : 0;
+                const bTs = Number.isFinite(Number(b.ts)) ? Number(b.ts) : 0;
+                return aTs - bTs;
+            });
+            this.history = normalized.slice(-20).map((entry) => ({
+                type: sanitizeText(entry.type || 'Event'),
+                message: sanitizeText(entry.message || ''),
+                points: Number.isFinite(Number(entry.points)) ? Number(entry.points) : 1,
+                ts: Number.isFinite(Number(entry.ts)) ? Number(entry.ts) : null,
+                elapsed: Number.isFinite(Number(entry.elapsed)) ? Number(entry.elapsed) : null,
+            }));
+        },
+        loadSpeedrun() {
+            const stored = parseJson(readStorage(SPEEDRUN_KEY));
+            this.speedrunTimes = stored && typeof stored === 'object' ? stored : {};
+            Object.keys(this.speedrunTimes).forEach((key) => {
+                const record = this.speedrunTimes[key];
+                if (!record || typeof record !== 'object') {
+                    delete this.speedrunTimes[key];
+                    return;
+                }
+                const elapsed = Number(record.elapsed);
+                if (!Number.isFinite(elapsed)) {
+                    delete this.speedrunTimes[key];
+                    return;
+                }
+                this.speedrunTimes[key] = {
+                    elapsed,
+                    ts: Number.isFinite(Number(record.ts)) ? Number(record.ts) : null,
+                    message: sanitizeText(record.message || ''),
+                };
+            });
+            if (speedrunSeed && typeof speedrunSeed === 'object') {
+                Object.keys(speedrunSeed).forEach((key) => {
+                    const seedRecord = speedrunSeed[key];
+                    if (!seedRecord || typeof seedRecord !== 'object') {
+                        return;
+                    }
+                    const seedElapsed = Number(seedRecord.elapsed);
+                    if (!Number.isFinite(seedElapsed)) {
+                        return;
+                    }
+                    const current = this.speedrunTimes[key];
+                    const currentElapsed = current && Number.isFinite(Number(current.elapsed)) ? Number(current.elapsed) : null;
+                    if (currentElapsed === null || seedElapsed < currentElapsed) {
+                        this.speedrunTimes[key] = {
+                            elapsed: seedElapsed,
+                            ts: Number.isFinite(Number(seedRecord.ts)) ? Number(seedRecord.ts) : null,
+                            message: sanitizeText(seedRecord.message || ''),
+                        };
+                    }
+                });
+            }
+        },
+        ensureRunStart() {
+            const stored = parseInt(readStorage(RUN_KEY), 10);
+            if (Number.isFinite(stored)) {
+                this.runStart = stored;
+            } else if (Number.isFinite(runStartMeta)) {
+                this.runStart = runStartMeta;
+            } else if (!this.runStart && this.history.length) {
+                const first = this.history[0];
+                if (first) {
+                    const firstTs = Number(first.ts);
+                    const firstElapsed = Number(first.elapsed);
+                    if (Number.isFinite(firstTs) && Number.isFinite(firstElapsed)) {
+                        this.runStart = Math.max(0, Math.floor(firstTs - firstElapsed));
+                    }
+                }
+            }
+            if (Number.isFinite(this.runStart) && this.runStart > 0) {
+                writeStorage(RUN_KEY, this.runStart);
+            }
+        },
+        captureRunStart(event) {
+            if (this.runStart && Number.isFinite(this.runStart)) {
+                return;
+            }
+            if (event) {
+                const elapsed = Number(event.elapsed);
+                if (!Number.isFinite(elapsed)) {
+                    return;
+                }
+                const eventTs = Number(event.ts);
+                const timestamp = Number.isFinite(eventTs) ? eventTs : Math.floor(Date.now() / 1000);
+                this.runStart = Math.max(0, Math.floor(timestamp - elapsed));
+            }
+        },
+        recordHistory(event) {
+            if (!event) {
+                return;
+            }
+            const entry = {
+                type: sanitizeText(event.type || 'Event'),
+                message: sanitizeText(event.message || ''),
+                points: Number.isFinite(Number(event.points)) ? Number(event.points) : 1,
+                ts: Number.isFinite(Number(event.ts)) ? Number(event.ts) : Math.floor(Date.now() / 1000),
+                elapsed: Number.isFinite(Number(event.elapsed)) ? Number(event.elapsed) : null,
+            };
+            this.history.push(entry);
+            if (this.history.length > 20) {
+                this.history = this.history.slice(-20);
+            }
+        },
+        renderHistory() {
+            if (!historyList) {
+                return;
+            }
+            historyList.innerHTML = '';
+            if (!this.history.length) {
+                const empty = document.createElement('li');
+                empty.textContent = 'No findings recorded yet.';
+                historyList.appendChild(empty);
+                return;
+            }
+            const recent = this.history.slice(-4).reverse();
+            recent.forEach((entry) => {
+                const item = document.createElement('li');
+                const title = document.createElement('strong');
+                title.textContent = `${entry.type}: ${entry.message}`;
+                const metaLine = document.createElement('div');
+                metaLine.className = 'rat-scoreboard-history-meta';
+                const elapsedLabel = Number.isFinite(entry.elapsed) ? `T+${formatElapsed(entry.elapsed)}` : 'Time unknown';
+                metaLine.innerHTML = `<span>+${entry.points}</span><span>${elapsedLabel}</span>`;
+                item.appendChild(title);
+                item.appendChild(metaLine);
+                historyList.appendChild(item);
+            });
+        },
+        updateSpeedrun(event) {
+            if (!event || !event.type) {
+                return;
+            }
+            const key = String(event.type).toUpperCase();
+            const elapsed = Number(event.elapsed);
+            if (!Number.isFinite(elapsed)) {
+                return;
+            }
+            const existing = this.speedrunTimes[key];
+            const shouldUpdate = !existing || !Number.isFinite(Number(existing.elapsed)) || elapsed < Number(existing.elapsed);
+            if (shouldUpdate) {
+                this.speedrunTimes[key] = {
+                    elapsed,
+                    ts: Number.isFinite(Number(event.ts)) ? Number(event.ts) : Math.floor(Date.now() / 1000),
+                    message: sanitizeText(event.message || ''),
+                };
+            }
+        },
+        renderSpeedrun() {
+            Object.keys(speedrunNodes).forEach((key) => {
+                const node = speedrunNodes[key];
+                if (!node || !node.parentElement) {
+                    return;
+                }
+                const parent = node.parentElement;
+                const record = this.speedrunTimes[key];
+                const elapsed = record ? Number(record.elapsed) : null;
+                if (record && Number.isFinite(elapsed)) {
+                    node.textContent = `T+${formatElapsed(elapsed)}`;
+                    parent.classList.add('rat-scoreboard-speedrun-unlocked');
+                } else {
+                    node.textContent = 'Locked';
+                    parent.classList.remove('rat-scoreboard-speedrun-unlocked');
+                }
+            });
+        },
+        ensureTimer() {
+            if (!timerValue) {
+                return;
+            }
+            if (!Number.isFinite(this.runStart) || this.runStart <= 0) {
+                timerValue.textContent = '--:--';
+                if (this.timerHandle) {
+                    clearInterval(this.timerHandle);
+                    this.timerHandle = null;
+                }
+                return;
+            }
+            if (!this.timerHandle) {
+                this.timerHandle = window.setInterval(() => {
+                    this.updateTimerDisplay();
+                }, 1000);
+            }
+            this.updateTimerDisplay();
+        },
+        updateTimerDisplay() {
+            if (!timerValue) {
+                return;
+            }
+            if (!Number.isFinite(this.runStart) || this.runStart <= 0) {
+                timerValue.textContent = '--:--';
+                return;
+            }
+            const now = Math.floor(Date.now() / 1000);
+            timerValue.textContent = formatElapsed(Math.max(0, now - this.runStart));
+        },
+        persistState() {
+            writeStorage(SCORE_KEY, this.score);
+            writeStorage(MAX_KEY, this.max);
+            try {
+                writeStorage(HISTORY_KEY, JSON.stringify(this.history));
+            } catch (err) {
+                // ignore serialization issues
+            }
+            try {
+                writeStorage(SPEEDRUN_KEY, JSON.stringify(this.speedrunTimes));
+            } catch (err) {
+                // ignore serialization issues
+            }
+            if (Number.isFinite(this.runStart) && this.runStart > 0) {
+                writeStorage(RUN_KEY, this.runStart);
             }
         },
     };


### PR DESCRIPTION
## Summary
- track temporary tenant metadata, elapsed run time, and per-category unlocks in session and expose them to the frontend
- overhaul the floating scoreboard with a tenant-scoped timer, history log, and BAC/IDOR speedrun challenge UI
- mask the Rat Track guidance until the relevant bugs are triggered and show unlock timing alongside a new speedrun progress card
- add styles to support the masked guide content and speedrun status display
- add the Google Analytics global site tag to the shared header so every page reports into G-TMQL73DM4R

## Testing
- php -l partials/header.php

------
https://chatgpt.com/codex/tasks/task_b_68cd27076b2c832982af12b81168bf03