### PR TITLE
Improve responsive layout and navigation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -17,6 +17,18 @@
     box-sizing: border-box;
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 body {
     margin: 0;
     font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
@@ -75,6 +87,15 @@ html.is-embedded .main-content {
     padding: 22px 32px;
     max-width: 1200px;
     margin: 0 auto;
+    gap: 20px;
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: rgba(255, 247, 234, 0.86);
+    border-bottom: 1px solid rgba(93, 44, 168, 0.12);
+    backdrop-filter: blur(18px);
+    border-radius: 32px;
+    box-shadow: 0 22px 45px rgba(27, 17, 85, 0.12);
 }
 
 .brand {
@@ -100,6 +121,7 @@ html.is-embedded .main-content {
     display: flex;
     gap: 16px;
     align-items: center;
+    margin-left: auto;
 }
 
 .nav-link {
@@ -109,6 +131,12 @@ html.is-embedded .main-content {
     text-decoration: none;
     color: var(--park-purple);
     transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:focus-visible,
+.nav-toggle:focus-visible {
+    outline: 3px solid rgba(93, 44, 168, 0.45);
+    outline-offset: 3px;
 }
 
 .nav-link:hover {
@@ -130,6 +158,74 @@ html.is-embedded .main-content {
 
 .main-content {
     flex: 1;
+}
+
+.nav-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    border: 1px solid rgba(93, 44, 168, 0.18);
+    background: rgba(255, 255, 255, 0.55);
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    position: relative;
+    z-index: 25;
+}
+
+.nav-toggle:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(93, 44, 168, 0.32);
+}
+
+.nav-toggle__bar {
+    position: absolute;
+    width: 22px;
+    height: 2px;
+    background: var(--park-purple);
+    border-radius: 999px;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.nav-toggle__bar:nth-child(1) {
+    transform: translateY(-7px);
+}
+
+.nav-toggle__bar:nth-child(2) {
+    transform: translateY(0);
+}
+
+.nav-toggle__bar:nth-child(3) {
+    transform: translateY(7px);
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle__bar:nth-child(1) {
+    transform: translateY(0) rotate(45deg);
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle__bar:nth-child(2) {
+    opacity: 0;
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle__bar:nth-child(3) {
+    transform: translateY(0) rotate(-45deg);
+}
+
+body.nav-open {
+    overflow: hidden;
+}
+
+body.nav-open::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: rgba(27, 17, 85, 0.35);
+    backdrop-filter: blur(2px);
+    z-index: 15;
+    pointer-events: auto;
 }
 
 .section {
@@ -902,24 +998,109 @@ textarea.input-field:focus {
         min-height: 520px;
     }
 }
-
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     .top-nav {
-        flex-direction: column;
-        gap: 16px;
+        max-width: none;
+        margin: 0 24px;
+        border-radius: 26px;
+    }
+
+    .section {
+        padding: 56px 24px 90px;
+    }
+
+    .section__inner {
+        max-width: 900px;
+    }
+
+    .hero-card {
+        padding: clamp(32px, 6vw, 44px);
+    }
+
+    .hero-actions {
+        gap: 14px;
+    }
+
+    .stats-grid,
+    .feature-grid {
+        gap: 24px;
+    }
+
+    .settings-shell,
+    .module-shell {
+        gap: 36px;
+    }
+}
+
+@media (max-width: 900px) {
+    .top-nav {
+        margin: 0;
+        border-radius: 0;
+        padding: 18px 24px;
+    }
+
+    .nav-toggle {
+        display: inline-flex;
     }
 
     .nav-links {
-        flex-wrap: wrap;
+        position: fixed;
+        top: 78px;
+        right: 24px;
+        left: 24px;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+        padding: 24px;
+        background: rgba(255, 247, 234, 0.97);
+        border-radius: 24px;
+        box-shadow: 0 24px 60px rgba(27, 17, 85, 0.22);
+        transform: translateY(-12px);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.25s ease, opacity 0.2s ease;
+        margin-left: 0;
+        z-index: 30;
+        max-height: calc(100vh - 120px);
+        overflow-y: auto;
+    }
+
+    .nav-links.is-open {
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .nav-link {
+        width: 100%;
         justify-content: center;
+        padding: 14px 18px;
+    }
+
+    .section {
+        padding: 52px 20px 80px;
+    }
+
+    .hero-card {
+        border-radius: 24px;
+    }
+
+    .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .hero-actions .btn {
+        width: 100%;
+    }
+
+    .stats-grid,
+    .feature-grid {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 
     .form-card {
         padding: 32px 28px 38px;
-    }
-
-    .settings-shell {
-        gap: 32px;
     }
 
     .settings-grid {
@@ -930,12 +1111,8 @@ textarea.input-field:focus {
         padding: 24px;
     }
 
-    .module-shell {
-        gap: 32px;
-    }
-
     .module-card {
-        padding: 24px;
+        padding: 26px;
     }
 
     .module-table th,
@@ -950,5 +1127,120 @@ textarea.input-field:focus {
     .module-actions {
         flex-direction: column;
         align-items: stretch;
+    }
+}
+
+@media (max-width: 720px) {
+    .top-nav {
+        padding: 16px 20px;
+    }
+
+    .nav-links {
+        top: 72px;
+        right: 18px;
+        left: 18px;
+        padding: 20px;
+    }
+
+    .hero-card {
+        padding: 30px 24px;
+    }
+
+    .hero-title {
+        font-size: clamp(2rem, 9vw, 2.6rem);
+    }
+
+    .hero-lead {
+        font-size: 1rem;
+    }
+
+    .stats-grid,
+    .feature-grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+
+    .tenant-card {
+        padding: 20px;
+    }
+
+    .form-card {
+        padding: 30px 24px 36px;
+    }
+
+    .module-card {
+        padding: 24px;
+    }
+
+    .settings-shell,
+    .module-shell {
+        gap: 28px;
+    }
+
+    .module-stage {
+        min-height: 420px;
+    }
+}
+
+@media (max-width: 540px) {
+    .top-nav {
+        padding: 16px;
+    }
+
+    .nav-links {
+        top: 66px;
+        right: 16px;
+        left: 16px;
+        border-radius: 20px;
+    }
+
+    .nav-link {
+        padding: 12px 16px;
+        font-size: 1rem;
+    }
+
+    .hero-card {
+        padding: 26px 20px;
+    }
+
+    .hero-badge {
+        font-size: 0.8rem;
+        padding: 8px 16px;
+    }
+
+    .hero-actions {
+        gap: 12px;
+    }
+
+    .btn {
+        padding: 14px 22px;
+    }
+
+    .section {
+        padding: 44px 16px 72px;
+    }
+
+    .site-footer {
+        padding: 28px 20px 36px;
+        font-size: 0.85rem;
+    }
+
+    .module-table th,
+    .module-table td {
+        font-size: 0.95rem;
+    }
+
+    .form-card {
+        padding: 26px 20px 32px;
+        border-radius: 22px;
+    }
+
+    .tenant-card {
+        border-radius: 16px;
+    }
+
+    .module-card {
+        padding: 22px;
+        border-radius: 22px;
     }
 }

--- a/partials/header.php
+++ b/partials/header.php
@@ -85,11 +85,75 @@ if ($tenantMetaJson === false) {
             <span class="brand__badge">RatPack</span>
             <span>Park OS</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="sr-only">Toggle navigation</span>
+        </button>
+        <nav id="primary-navigation" class="nav-links">
             <a class="nav-link<?php echo $activePage === 'home' ? ' active' : ''; ?>" href="index.php">Home</a>
             <a class="nav-link<?php echo $activePage === 'dashboard' ? ' active' : ''; ?>" href="dashboard.php">Dashboard</a>
             <a class="nav-link<?php echo $activePage === 'login' ? ' active' : ''; ?>" href="login.php">Login</a>
             <a class="nav-link nav-link--primary<?php echo $activePage === 'register' ? ' active' : ''; ?>" href="register.php">Start Trial</a>
         </nav>
     </header>
+    <script>
+        (function () {
+            const navToggle = document.querySelector('.nav-toggle');
+            const navLinks = document.getElementById('primary-navigation');
+            if (!navToggle || !navLinks) {
+                return;
+            }
+
+            const closeNav = () => {
+                navLinks.classList.remove('is-open');
+                navToggle.setAttribute('aria-expanded', 'false');
+                document.body.classList.remove('nav-open');
+            };
+
+            navToggle.addEventListener('click', () => {
+                const isOpen = navLinks.classList.toggle('is-open');
+                navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                document.body.classList.toggle('nav-open', isOpen);
+            });
+
+            navLinks.addEventListener('click', (event) => {
+                if (event.target instanceof HTMLElement && event.target.classList.contains('nav-link')) {
+                    closeNav();
+                }
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') {
+                    closeNav();
+                }
+            });
+
+            document.addEventListener('click', (event) => {
+                const target = event.target;
+                if (
+                    navLinks.classList.contains('is-open') &&
+                    target instanceof Node &&
+                    !navLinks.contains(target) &&
+                    !navToggle.contains(target)
+                ) {
+                    closeNav();
+                }
+            });
+
+            const mediaQuery = window.matchMedia('(max-width: 900px)');
+            const handleMediaChange = (event) => {
+                if (!event.matches) {
+                    closeNav();
+                }
+            };
+
+            if (typeof mediaQuery.addEventListener === 'function') {
+                mediaQuery.addEventListener('change', handleMediaChange);
+            } else if (typeof mediaQuery.addListener === 'function') {
+                mediaQuery.addListener(handleMediaChange);
+            }
+        })();
+    </script>
     <main class="main-content">


### PR DESCRIPTION
## Summary
- add a mobile-first navigation toggle and overlay so the header behaves like an app on small screens
- retune spacing, card radii, and grids across sections to better fit tablet and phone breakpoints
- add accessibility touches such as focus outlines and an sr-only helper to support the new layout

## Testing
- php -l partials/header.php

------
https://chatgpt.com/codex/tasks/task_b_68cd37e0a02c832993ad66d0783d14d3